### PR TITLE
Add FLASK_APP and Windows setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Flask Example
+
+This project uses Flask.
+
+## Setting the FLASK_APP environment variable
+
+Set the `FLASK_APP` variable before running Flask commands:
+
+- **Linux/Mac**:
+  ```sh
+  export FLASK_APP=main.py
+  ```
+- **Windows CMD**:
+  ```cmd
+  set FLASK_APP=main.py
+  ```
+- **PowerShell**:
+  ```powershell
+  $env:FLASK_APP = 'main.py'
+  ```
+
+## Activating the virtual environment
+
+```sh
+source venv/bin/activate      # Linux/Mac
+venv\Scripts\activate        # Windows
+```
+
+## Running the app
+
+After activating the environment and setting `FLASK_APP`, run:
+
+```sh
+flask run
+```
+


### PR DESCRIPTION
## Summary
- add README with steps on activating virtualenv
- document how to set the `FLASK_APP` environment variable on different platforms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686264e6e838832989aa8b893da7e212