### PR TITLE
Expande monitor com gestão completa de clientes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,141 @@
+# Monitoramento do eCAC
+
+Este repositório contém uma ferramenta CLI em Python para monitorar periodicamente o eCAC para escritórios de contabilidade. Ela autentica usando o certificado digital de cada contribuinte (empresa ou pessoa física) e a procuração eletrônica do contador, consulta uma API proprietária e registra novos eventos em um banco SQLite, disparando alertas via webhook.
+
+## Requisitos
+
+- Python 3.9 ou superior
+- Bibliotecas [`requests`](https://pypi.org/project/requests/) e [`Flask`](https://flask.palletsprojects.com/)
+- Certificados digitais (`.pem`) de cada cliente e procuração eletrônica ativa para o contador
+- API própria do escritório capaz de autenticar e consultar notificações/obrigações do eCAC
+
+Instale a dependência:
+
+```bash
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+## Configuração da API
+
+1. Copie o arquivo de exemplo `monitor_config.example.json` para `monitor_config.json` e edite os valores:
+   - `api_base_url`: URL base da API proprietária (sem barra no final).
+   - `contador_document`: CPF/CNPJ do contador com procuração.
+   - `procuracao_token`: token padrão usado na autorização.
+   - Opcional: `poll_interval`, `verify_ssl`, `timeout`, `webhook_url`.
+2. Garanta que os certificados `.pem` de cada cliente estejam acessíveis no servidor onde o monitor rodará.
+
+## Banco de dados
+
+O monitor cria automaticamente o arquivo SQLite definido por `--database` (padrão `monitor.db`) com as tabelas `clients` e `events`. Faça backup periódico desse arquivo se precisar de histórico.
+
+## Cadastro de clientes
+
+Execute o comando abaixo para cada cliente, informando os caminhos dos certificados e, se necessário, a senha do certificado e token de procuração específico:
+
+```bash
+python main.py add-client \
+  --database monitor.db \
+  12345678000190 "Empresa Exemplo Ltda" PJ \
+  /caminho/certificados/empresa.pem \
+  /caminho/certificados/empresa-key.pem \
+  --certificate-password "senhaOpcional" \
+  --procuracao-token "tokenOpcional"
+```
+
+Para listar os clientes cadastrados:
+
+```bash
+python main.py list-clients --database monitor.db
+```
+
+### Atualização, remoção e status de clientes
+
+- Atualize informações (nome, tipo, caminhos de arquivos ou credenciais específicas):
+
+  ```bash
+  python main.py update-client \
+    --database monitor.db \
+    12345678000190 \
+    --name "Empresa Nova" \
+    --certificate /novo/caminho/cert.pem \
+    --key /novo/caminho/key.pem
+  ```
+
+- Remova um cliente (os eventos associados também são excluídos):
+
+  ```bash
+  python main.py delete-client --database monitor.db 12345678000190
+  ```
+
+- Consulte o último status consolidado retornado pela API:
+
+  ```bash
+  python main.py show-status --database monitor.db 12345678000190
+  ```
+
+- Liste eventos registrados, com suporte a filtros e paginação simples:
+
+  ```bash
+  python main.py list-events --database monitor.db --document 12345678000190 --limit 20
+  ```
+
+## Execução do monitoramento
+
+### Execução contínua
+
+Para rodar continuamente (modo daemon simples), use:
+
+```bash
+python main.py run --database monitor.db --config monitor_config.json
+```
+
+O processo fica em loop consultando a API a cada `poll_interval` segundos, atualizando o banco e enviando alertas para o webhook (quando configurado).
+
+### Execução de ciclo único
+
+Se quiser executar apenas um ciclo (por exemplo, em uma pipeline agendada ou cron job), adicione `--once`:
+
+```bash
+python main.py run --database monitor.db --config monitor_config.json --once
+```
+
+Para executar o ciclo apenas para um cliente específico (útil em fluxos manuais ou integrações), informe `--client`:
+
+```bash
+python main.py run --database monitor.db --config monitor_config.json --client 12345678000190
+```
+
+## Interface web
+
+Além da CLI, o repositório inclui um painel web simples (`webapp.py`) para cadastrar clientes e disparar ciclos manuais do monitor.
+
+1. Configure as variáveis de ambiente:
+   ```bash
+   export MONITOR_DATABASE=monitor.db
+   export MONITOR_CONFIG=/caminho/para/monitor_config.json
+   export FLASK_SECRET_KEY="uma-string-aleatoria"
+   ```
+2. Inicie o servidor:
+   ```bash
+   python webapp.py
+   ```
+3. Acesse `http://localhost:8000` para visualizar clientes, cadastrar novos, editar registros, remover cadastros, examinar o
+   histórico de eventos e executar ciclos sob demanda (globais ou por cliente).
+
+O painel reutiliza o mesmo banco SQLite e respeita as configurações do arquivo JSON. Certifique-se de que o processo tenha acesso
+aos certificados de cada cliente.
+
+## Logs e observabilidade
+
+Os logs são enviados para `stdout` com nível `INFO` por padrão. Para aumentar a verbosidade, ajuste a variável de ambiente `PYTHONLOGLEVEL` ou modifique `logging.basicConfig` em `main.py`.
+
+## Deploy sugerido
+
+- Configure um serviço do sistema (ex.: `systemd`) para iniciar o comando contínuo após o boot.
+- Armazene os certificados em diretório protegido, com permissões restritas ao usuário que executa o monitor.
+- Utilize `venv` dedicado para isolar as dependências Python.
+
+## Suporte
+
+Em caso de dúvidas, entre em contato com o time responsável pela API proprietária ou adapte o código para atender às particularidades do seu escritório.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ python main.py run --database monitor.db --config monitor_config.json --client 1
 
 ## Interface web
 
-Além da CLI, o repositório inclui um painel web simples (`webapp.py`) para cadastrar clientes e disparar ciclos manuais do monitor.
+Além da CLI, o repositório inclui um painel web completo (`webapp.py`) para cadastrar clientes, visualizar métricas consolidadas e disparar ciclos manuais do monitor.
 
 1. Configure as variáveis de ambiente:
    ```bash
@@ -122,6 +122,14 @@ Além da CLI, o repositório inclui um painel web simples (`webapp.py`) para cad
    ```
 3. Acesse `http://localhost:8000` para visualizar clientes, cadastrar novos, editar registros, remover cadastros, examinar o
    histórico de eventos e executar ciclos sob demanda (globais ou por cliente).
+
+### Recursos disponíveis no painel
+
+- **Dashboard operacional** com contadores de clientes, eventos, últimos ciclos e destaque para clientes que precisam de nova verificação.
+- **Linha do tempo dos eventos** com visualização amigável, filtros de paginação, destaque de categorias/referências e exibição do payload bruto por evento.
+- **Páginas de detalhe** para cada cliente exibindo notificações mais recentes, obrigações, metadados retornados pela API e ações rápidas (rodar ciclo, editar, remover).
+- **Formulários estruturados** para cadastro e edição, incluindo dicas operacionais ao lado dos campos obrigatórios.
+- **Estilo responsivo** baseado em Bulma com personalizações próprias (`static/css/app.css`) para cards, timeline e blocos de informação.
 
 O painel reutiliza o mesmo banco SQLite e respeita as configurações do arquivo JSON. Certifique-se de que o processo tenha acesso
 aos certificados de cada cliente.

--- a/main.py
+++ b/main.py
@@ -1,1 +1,746 @@
+"""Ferramenta de monitoramento contínuo do eCAC para escritórios de contabilidade.
 
+Este módulo fornece uma linha de comando para registrar clientes (empresas ou pessoas
+físicas) e acompanhar notificações do eCAC por meio de uma API própria do escritório.
+As requisições são autenticadas com o certificado digital do contribuinte e com a
+procuração eletrônica do contador.
+
+O código foi escrito para ser direto e pronto para uso em produção, sem mocks
+ou simulações. Ajuste apenas as configurações de acesso (endereços da API,
+caminhos dos certificados, tokens de procuração e URLs de alerta) antes de
+colocá-lo em operação.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+try:
+    import requests
+except ImportError as exc:  # pragma: no cover - dependência obrigatória em produção
+    raise SystemExit(
+        "Dependência 'requests' não encontrada. Instale-a com 'pip install requests'."
+    ) from exc
+
+LOGGER = logging.getLogger("ecac_monitor")
+
+
+@dataclass
+class MonitorConfig:
+    """Representa a configuração principal do monitor."""
+
+    api_base_url: str
+    contador_document: str
+    procuracao_token: str
+    poll_interval: int = 900
+    verify_ssl: bool = True
+    timeout: int = 60
+    webhook_url: Optional[str] = None
+
+    @classmethod
+    def load(cls, path: Path) -> "MonitorConfig":
+        with path.open("r", encoding="utf-8") as fp:
+            data = json.load(fp)
+        required = {"api_base_url", "contador_document", "procuracao_token"}
+        missing = [field for field in required if field not in data]
+        if missing:
+            raise ValueError(
+                f"Configuração inválida: campos obrigatórios ausentes {', '.join(missing)}"
+            )
+        return cls(
+            api_base_url=data["api_base_url"].rstrip("/"),
+            contador_document=data["contador_document"],
+            procuracao_token=data["procuracao_token"],
+            poll_interval=int(data.get("poll_interval", 900)),
+            verify_ssl=bool(data.get("verify_ssl", True)),
+            timeout=int(data.get("timeout", 60)),
+            webhook_url=data.get("webhook_url"),
+        )
+
+
+@dataclass
+class Client:
+    document: str
+    name: str
+    client_type: str  # PJ ou PF
+    certificate_path: Path
+    key_path: Path
+    certificate_password: Optional[str]
+    procuracao_token: Optional[str]
+    last_status: Optional[str]
+    last_checked: Optional[datetime]
+
+
+@dataclass
+class EventRecord:
+    id: int
+    client_document: str
+    payload: Dict[str, Any]
+    received_at: datetime
+
+
+class DatabaseManager:
+    """Responsável por persistir dados locais do monitor."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS clients (
+                    document TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    client_type TEXT NOT NULL CHECK (client_type IN ('PJ', 'PF')),
+                    certificate_path TEXT NOT NULL,
+                    key_path TEXT NOT NULL,
+                    certificate_password TEXT,
+                    procuracao_token TEXT,
+                    last_status TEXT,
+                    last_checked TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    client_document TEXT NOT NULL,
+                    event_hash TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    received_at TEXT NOT NULL,
+                    FOREIGN KEY (client_document) REFERENCES clients(document)
+                );
+
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_events_document_hash
+                    ON events(client_document, event_hash);
+                """
+            )
+
+    # Métodos públicos -------------------------------------------------
+    def add_client(
+        self,
+        document: str,
+        name: str,
+        client_type: str,
+        certificate_path: Path,
+        key_path: Path,
+        certificate_password: Optional[str],
+        procuracao_token: Optional[str],
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO clients (
+                    document, name, client_type, certificate_path, key_path,
+                    certificate_password, procuracao_token
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    document,
+                    name,
+                    client_type,
+                    str(certificate_path),
+                    str(key_path),
+                    certificate_password,
+                    procuracao_token,
+                ),
+            )
+
+    def list_clients(self) -> List[Client]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT document, name, client_type, certificate_path, key_path, "
+                "certificate_password, procuracao_token, last_status, last_checked FROM clients"
+            ).fetchall()
+        clients: List[Client] = []
+        for row in rows:
+            last_checked = (
+                datetime.fromisoformat(row["last_checked"]) if row["last_checked"] else None
+            )
+            clients.append(
+                Client(
+                    document=row["document"],
+                    name=row["name"],
+                    client_type=row["client_type"],
+                    certificate_path=Path(row["certificate_path"]),
+                    key_path=Path(row["key_path"]),
+                    certificate_password=row["certificate_password"],
+                    procuracao_token=row["procuracao_token"],
+                    last_status=row["last_status"],
+                    last_checked=last_checked,
+                )
+            )
+        return clients
+
+    def get_client(self, document: str) -> Optional[Client]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT document, name, client_type, certificate_path, key_path, "
+                "certificate_password, procuracao_token, last_status, last_checked "
+                "FROM clients WHERE document = ?",
+                (document,),
+            ).fetchone()
+        if row is None:
+            return None
+        last_checked = datetime.fromisoformat(row["last_checked"]) if row["last_checked"] else None
+        return Client(
+            document=row["document"],
+            name=row["name"],
+            client_type=row["client_type"],
+            certificate_path=Path(row["certificate_path"]),
+            key_path=Path(row["key_path"]),
+            certificate_password=row["certificate_password"],
+            procuracao_token=row["procuracao_token"],
+            last_status=row["last_status"],
+            last_checked=last_checked,
+        )
+
+    def update_status(self, document: str, status: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE clients SET last_status = ?, last_checked = ? WHERE document = ?",
+                (status, datetime.utcnow().isoformat(), document),
+            )
+
+    def register_events(self, document: str, events: Sequence[Dict]) -> List[Dict]:
+        """Registra eventos inéditos e retorna apenas os novos."""
+
+        if not events:
+            return []
+
+        created: List[Dict] = []
+        with self._connect() as conn:
+            for event in events:
+                normalized = json.dumps(event, sort_keys=True, ensure_ascii=False)
+                event_hash = hashlib.sha1(normalized.encode("utf-8")).hexdigest()
+                try:
+                    conn.execute(
+                        """
+                        INSERT INTO events (client_document, event_hash, payload, received_at)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        (
+                            document,
+                            event_hash,
+                            normalized,
+                            datetime.utcnow().isoformat(),
+                        ),
+                    )
+                except sqlite3.IntegrityError:
+                    continue
+                created.append(event)
+        return created
+
+    def list_events(
+        self,
+        document: Optional[str] = None,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[EventRecord]:
+        query = (
+            "SELECT id, client_document, payload, received_at FROM events"
+            + (" WHERE client_document = ?" if document else "")
+            + " ORDER BY received_at DESC, id DESC LIMIT ? OFFSET ?"
+        )
+        params: List[Any]
+        if document:
+            params = [document, limit, offset]
+        else:
+            params = [limit, offset]
+        with self._connect() as conn:
+            rows = conn.execute(query, params).fetchall()
+        events: List[EventRecord] = []
+        for row in rows:
+            try:
+                payload = json.loads(row["payload"])
+            except json.JSONDecodeError:
+                payload = {"raw": row["payload"]}
+            events.append(
+                EventRecord(
+                    id=row["id"],
+                    client_document=row["client_document"],
+                    payload=payload,
+                    received_at=datetime.fromisoformat(row["received_at"]),
+                )
+            )
+        return events
+
+    def delete_client(self, document: str) -> None:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM events WHERE client_document = ?", (document,))
+            deleted = conn.execute("DELETE FROM clients WHERE document = ?", (document,)).rowcount
+        if not deleted:
+            raise ValueError(f"Cliente {document} não encontrado")
+
+    def update_client(self, document: str, **fields: Any) -> None:
+        allowed = {
+            "name": "name",
+            "client_type": "client_type",
+            "certificate_path": "certificate_path",
+            "key_path": "key_path",
+            "certificate_password": "certificate_password",
+            "procuracao_token": "procuracao_token",
+        }
+        assignments: List[str] = []
+        values: List[Any] = []
+        for key, column in allowed.items():
+            if key not in fields:
+                continue
+            assignments.append(f"{column} = ?")
+            value = fields[key]
+            if isinstance(value, Path):
+                value = str(value)
+            values.append(value)
+        if not assignments:
+            return
+        values.append(document)
+        with self._connect() as conn:
+            updated = conn.execute(
+                f"UPDATE clients SET {', '.join(assignments)} WHERE document = ?",
+                values,
+            ).rowcount
+        if not updated:
+            raise ValueError(f"Cliente {document} não encontrado")
+
+
+class EcacAPIClient:
+    """Cliente HTTP que interage com a API proprietária."""
+
+    def __init__(self, config: MonitorConfig) -> None:
+        self.config = config
+
+    def _prepare_session(
+        self, client: Client, verify_ssl: bool
+    ) -> requests.Session:
+        session = requests.Session()
+        session.verify = verify_ssl
+        session.cert = (str(client.certificate_path), str(client.key_path))
+        if client.certificate_password:
+            session.headers["X-Certificate-Pin"] = client.certificate_password
+        session.headers.update({
+            "User-Agent": "ecac-monitor/1.0",
+            "X-Contador-Documento": self.config.contador_document,
+            "X-Procuracao-Token": client.procuracao_token or self.config.procuracao_token,
+        })
+        return session
+
+    def authenticate(self, session: requests.Session, client: Client) -> str:
+        response = session.post(
+            f"{self.config.api_base_url}/auth/certificate",
+            timeout=self.config.timeout,
+            json={
+                "document": client.document,
+                "client_type": client.client_type,
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+        token = data.get("access_token")
+        if not token:
+            raise RuntimeError("Resposta da API sem access_token")
+        return token
+
+    def fetch_notifications(
+        self, session: requests.Session, token: str, document: str
+    ) -> List[Dict]:
+        response = session.get(
+            f"{self.config.api_base_url}/ecac/{document}/notifications",
+            timeout=self.config.timeout,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        notifications = payload.get("notifications")
+        if notifications is None:
+            raise RuntimeError("Resposta inesperada da API: campo 'notifications' ausente")
+        if not isinstance(notifications, list):
+            raise RuntimeError("Campo 'notifications' deve ser uma lista")
+        return notifications
+
+    def fetch_obligations(
+        self, session: requests.Session, token: str, document: str
+    ) -> List[Dict]:
+        response = session.get(
+            f"{self.config.api_base_url}/ecac/{document}/obligations",
+            timeout=self.config.timeout,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        obligations = payload.get("obligations", [])
+        if not isinstance(obligations, list):
+            raise RuntimeError("Campo 'obligations' deve ser uma lista")
+        return obligations
+
+
+class AlertDispatcher:
+    def __init__(self, webhook_url: Optional[str], verify_ssl: bool, timeout: int) -> None:
+        self.webhook_url = webhook_url
+        self.verify_ssl = verify_ssl
+        self.timeout = timeout
+
+    def dispatch(self, payload: Dict) -> None:
+        if not self.webhook_url:
+            return
+        response = requests.post(
+            self.webhook_url,
+            json=payload,
+            timeout=self.timeout,
+            verify=self.verify_ssl,
+        )
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            LOGGER.exception("Falha ao enviar alerta para %s", self.webhook_url)
+            raise
+
+
+class EcacMonitor:
+    def __init__(
+        self,
+        db: DatabaseManager,
+        api_client: EcacAPIClient,
+        dispatcher: AlertDispatcher,
+        poll_interval: int,
+        verify_ssl: bool,
+    ) -> None:
+        self.db = db
+        self.api_client = api_client
+        self.dispatcher = dispatcher
+        self.poll_interval = poll_interval
+        self.verify_ssl = verify_ssl
+
+    def run_forever(self) -> None:
+        LOGGER.info("Monitoramento iniciado")
+        while True:
+            start = time.monotonic()
+            self.run_cycle()
+            elapsed = time.monotonic() - start
+            sleep_time = max(self.poll_interval - elapsed, 5)
+            LOGGER.debug("Aguardando %.1f segundos até o próximo ciclo", sleep_time)
+            time.sleep(sleep_time)
+
+    def run_cycle(self) -> None:
+        for client in self.db.list_clients():
+            self._process_client(client)
+
+    def run_for_client(self, document: str) -> None:
+        client = self.db.get_client(document)
+        if not client:
+            raise ValueError(f"Cliente {document} não encontrado")
+        self._process_client(client)
+
+    def _process_client(self, client: Client) -> None:
+        LOGGER.info("Verificando %s (%s)", client.name, client.document)
+        session = self.api_client._prepare_session(client, self.verify_ssl)
+        try:
+            token = self.api_client.authenticate(session, client)
+            notifications = self.api_client.fetch_notifications(session, token, client.document)
+            obligations = self.api_client.fetch_obligations(session, token, client.document)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.exception("Falha ao comunicar com a API do eCAC: %s", exc)
+            return
+
+        new_events = self.db.register_events(client.document, notifications)
+        status_payload = {
+            "notifications": notifications,
+            "obligations": obligations,
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+        self.db.update_status(client.document, json.dumps(status_payload, ensure_ascii=False))
+
+        if new_events:
+            LOGGER.info("%s novos eventos encontrados para %s", len(new_events), client.document)
+            self._emit_alert(client, new_events, obligations)
+        else:
+            LOGGER.info("Nenhum evento novo para %s", client.document)
+
+    def _emit_alert(
+        self,
+        client: Client,
+        new_events: Iterable[Dict],
+        obligations: Sequence[Dict],
+    ) -> None:
+        payload = {
+            "client": {
+                "document": client.document,
+                "name": client.name,
+                "type": client.client_type,
+            },
+            "new_notifications": list(new_events),
+            "open_obligations": obligations,
+            "generated_at": datetime.utcnow().isoformat(),
+        }
+        try:
+            self.dispatcher.dispatch(payload)
+        except Exception:  # noqa: BLE001
+            LOGGER.exception("Erro ao enviar alerta do cliente %s", client.document)
+
+
+# ---------------------------------------------------------------------------
+# Linha de comando
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Monitoramento contínuo do eCAC")
+    parser.add_argument(
+        "--database",
+        default="monitor.db",
+        help="Caminho do arquivo SQLite (padrão: monitor.db)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_client_cmd = subparsers.add_parser("add-client", help="Cadastra um novo cliente")
+    add_client_cmd.add_argument("document", help="CPF ou CNPJ do contribuinte")
+    add_client_cmd.add_argument("name", help="Nome ou razão social")
+    add_client_cmd.add_argument("client_type", choices=["PJ", "PF"], help="Tipo do cliente")
+    add_client_cmd.add_argument("certificate", help="Arquivo PEM do certificado da empresa")
+    add_client_cmd.add_argument("key", help="Arquivo PEM da chave privada correspondente")
+    add_client_cmd.add_argument(
+        "--certificate-password",
+        dest="certificate_password",
+        help="Senha do certificado (se aplicável)",
+    )
+    add_client_cmd.add_argument(
+        "--procuracao-token",
+        dest="procuracao_token",
+        help="Token de procuração específico do cliente (opcional)",
+    )
+
+    subparsers.add_parser("list-clients", help="Lista clientes cadastrados")
+
+    update_client_cmd = subparsers.add_parser(
+        "update-client", help="Atualiza informações de um cliente"
+    )
+    update_client_cmd.add_argument("document", help="CPF ou CNPJ do contribuinte")
+    update_client_cmd.add_argument("--name", help="Novo nome ou razão social")
+    update_client_cmd.add_argument(
+        "--client-type",
+        choices=["PJ", "PF"],
+        dest="client_type",
+        help="Atualiza o tipo do cliente",
+    )
+    update_client_cmd.add_argument("--certificate", help="Novo caminho do certificado")
+    update_client_cmd.add_argument("--key", help="Novo caminho da chave privada")
+    update_client_cmd.add_argument(
+        "--certificate-password",
+        dest="certificate_password",
+        help="Atualiza a senha do certificado",
+    )
+    update_client_cmd.add_argument(
+        "--procuracao-token",
+        dest="procuracao_token",
+        help="Atualiza o token de procuração",
+    )
+    update_client_cmd.add_argument(
+        "--clear-certificate-password",
+        action="store_true",
+        help="Remove a senha do certificado armazenada",
+    )
+    update_client_cmd.add_argument(
+        "--clear-procuracao-token",
+        action="store_true",
+        help="Remove o token de procuração armazenado",
+    )
+
+    delete_client_cmd = subparsers.add_parser(
+        "delete-client", help="Remove um cliente e seu histórico"
+    )
+    delete_client_cmd.add_argument("document", help="CPF ou CNPJ do contribuinte")
+
+    events_cmd = subparsers.add_parser(
+        "list-events", help="Lista eventos registrados no banco"
+    )
+    events_cmd.add_argument(
+        "--document",
+        help="Filtra eventos por documento do cliente",
+    )
+    events_cmd.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Quantidade máxima de eventos (padrão: 50)",
+    )
+    events_cmd.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Deslocamento para paginação (padrão: 0)",
+    )
+
+    status_cmd = subparsers.add_parser(
+        "show-status", help="Mostra o último status consolidado de um cliente"
+    )
+    status_cmd.add_argument("document", help="CPF ou CNPJ do contribuinte")
+
+    run_cmd = subparsers.add_parser("run", help="Executa o monitoramento contínuo")
+    run_cmd.add_argument(
+        "--config",
+        required=True,
+        help="Arquivo JSON com configuração do monitor",
+    )
+    run_cmd.add_argument(
+        "--once",
+        action="store_true",
+        help="Executa apenas um ciclo de consulta (útil para integrações)",
+    )
+    run_cmd.add_argument(
+        "--client",
+        help="Documento de um cliente específico para executar o ciclo",
+    )
+
+    return parser
+
+
+def handle_add_client(args: argparse.Namespace, db: DatabaseManager) -> None:
+    db.add_client(
+        document=args.document,
+        name=args.name,
+        client_type=args.client_type,
+        certificate_path=Path(args.certificate).expanduser(),
+        key_path=Path(args.key).expanduser(),
+        certificate_password=args.certificate_password,
+        procuracao_token=args.procuracao_token,
+    )
+    LOGGER.info("Cliente %s cadastrado com sucesso", args.document)
+
+
+def handle_list_clients(db: DatabaseManager) -> None:
+    clients = db.list_clients()
+    if not clients:
+        print("Nenhum cliente cadastrado.")
+        return
+    for client in clients:
+        last_checked = client.last_checked.isoformat() if client.last_checked else "nunca"
+        print(
+            f"{client.document} | {client.name} | {client.client_type} | "
+            f"última verificação: {last_checked}"
+        )
+
+
+def handle_update_client(args: argparse.Namespace, db: DatabaseManager) -> None:
+    fields: Dict[str, Any] = {}
+    if args.name:
+        fields["name"] = args.name
+    if args.client_type:
+        fields["client_type"] = args.client_type
+    if args.certificate:
+        fields["certificate_path"] = Path(args.certificate).expanduser()
+    if args.key:
+        fields["key_path"] = Path(args.key).expanduser()
+    if args.certificate_password is not None:
+        fields["certificate_password"] = args.certificate_password
+    if args.procuracao_token is not None:
+        fields["procuracao_token"] = args.procuracao_token
+    if args.clear_certificate_password:
+        fields["certificate_password"] = None
+    if args.clear_procuracao_token:
+        fields["procuracao_token"] = None
+    if not fields:
+        LOGGER.info("Nenhum campo informado para atualização")
+        return
+    db.update_client(args.document, **fields)
+    LOGGER.info("Cliente %s atualizado com sucesso", args.document)
+
+
+def handle_delete_client(args: argparse.Namespace, db: DatabaseManager) -> None:
+    db.delete_client(args.document)
+    LOGGER.info("Cliente %s removido", args.document)
+
+
+def handle_list_events(args: argparse.Namespace, db: DatabaseManager) -> None:
+    events = db.list_events(args.document, limit=args.limit, offset=args.offset)
+    if not events:
+        print("Nenhum evento encontrado.")
+        return
+    for event in events:
+        print(
+            f"[{event.received_at.isoformat()}] {event.client_document} - "
+            f"payload: {json.dumps(event.payload, ensure_ascii=False)}"
+        )
+
+
+def handle_show_status(args: argparse.Namespace, db: DatabaseManager) -> None:
+    client = db.get_client(args.document)
+    if not client:
+        print(f"Cliente {args.document} não encontrado.")
+        return
+    if not client.last_status:
+        print("Nenhum status registrado. Execute um ciclo de monitoramento.")
+        return
+    try:
+        status = json.loads(client.last_status)
+    except json.JSONDecodeError:
+        print(client.last_status)
+        return
+    print(json.dumps(status, indent=2, ensure_ascii=False))
+
+
+def handle_run(args: argparse.Namespace, db: DatabaseManager) -> None:
+    config = MonitorConfig.load(Path(args.config))
+    api_client = EcacAPIClient(config)
+    dispatcher = AlertDispatcher(config.webhook_url, config.verify_ssl, config.timeout)
+    monitor = EcacMonitor(db, api_client, dispatcher, config.poll_interval, config.verify_ssl)
+    if args.client:
+        monitor.run_for_client(args.client)
+        return
+    if args.once:
+        monitor.run_cycle()
+    else:
+        monitor.run_forever()
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    db = DatabaseManager(Path(args.database))
+
+    if args.command == "add-client":
+        handle_add_client(args, db)
+        return 0
+    if args.command == "list-clients":
+        handle_list_clients(db)
+        return 0
+    if args.command == "update-client":
+        handle_update_client(args, db)
+        return 0
+    if args.command == "delete-client":
+        handle_delete_client(args, db)
+        return 0
+    if args.command == "list-events":
+        handle_list_events(args, db)
+        return 0
+    if args.command == "show-status":
+        handle_show_status(args, db)
+        return 0
+    if args.command == "run":
+        handle_run(args, db)
+        return 0
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/main.py
+++ b/main.py
@@ -87,6 +87,20 @@ class EventRecord:
     client_document: str
     payload: Dict[str, Any]
     received_at: datetime
+    client_name: Optional[str] = None
+
+
+@dataclass
+class DashboardMetrics:
+    """Representa indicadores consolidados para o painel web."""
+
+    total_clients: int
+    pj_clients: int
+    pf_clients: int
+    total_events: int
+    clients_with_alerts: int
+    last_check: Optional[datetime]
+    last_event: Optional[datetime]
 
 
 class DatabaseManager:
@@ -255,9 +269,11 @@ class DatabaseManager:
         offset: int = 0,
     ) -> List[EventRecord]:
         query = (
-            "SELECT id, client_document, payload, received_at FROM events"
-            + (" WHERE client_document = ?" if document else "")
-            + " ORDER BY received_at DESC, id DESC LIMIT ? OFFSET ?"
+            "SELECT e.id, e.client_document, e.payload, e.received_at, c.name as client_name "
+            "FROM events e "
+            "LEFT JOIN clients c ON c.document = e.client_document "
+            + ("WHERE e.client_document = ? " if document else "")
+            + "ORDER BY datetime(e.received_at) DESC, e.id DESC LIMIT ? OFFSET ?"
         )
         params: List[Any]
         if document:
@@ -278,9 +294,42 @@ class DatabaseManager:
                     client_document=row["client_document"],
                     payload=payload,
                     received_at=datetime.fromisoformat(row["received_at"]),
+                    client_name=row["client_name"],
                 )
             )
         return events
+
+    def get_dashboard_metrics(self) -> DashboardMetrics:
+        with self._connect() as conn:
+            total_clients = conn.execute("SELECT COUNT(*) FROM clients").fetchone()[0]
+            type_counts = {
+                row["client_type"]: row["count"]
+                for row in conn.execute(
+                    "SELECT client_type, COUNT(*) as count FROM clients GROUP BY client_type"
+                ).fetchall()
+            }
+            last_check_raw = conn.execute("SELECT MAX(last_checked) FROM clients").fetchone()[0]
+            total_events = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+            clients_with_alerts = conn.execute(
+                "SELECT COUNT(DISTINCT client_document) FROM events"
+            ).fetchone()[0]
+            last_event_raw = conn.execute("SELECT MAX(received_at) FROM events").fetchone()[0]
+
+        last_check = (
+            datetime.fromisoformat(last_check_raw) if last_check_raw else None
+        )
+        last_event = (
+            datetime.fromisoformat(last_event_raw) if last_event_raw else None
+        )
+        return DashboardMetrics(
+            total_clients=total_clients,
+            pj_clients=type_counts.get("PJ", 0),
+            pf_clients=type_counts.get("PF", 0),
+            total_events=total_events,
+            clients_with_alerts=clients_with_alerts,
+            last_check=last_check,
+            last_event=last_event,
+        )
 
     def delete_client(self, document: str) -> None:
         with self._connect() as conn:

--- a/monitor_config.example.json
+++ b/monitor_config.example.json
@@ -1,0 +1,9 @@
+{
+  "api_base_url": "https://sua-api-interna.exemplo.com",
+  "contador_document": "00000000000",
+  "procuracao_token": "token-gerado-no-ecac-para-o-contador",
+  "poll_interval": 900,
+  "verify_ssl": true,
+  "timeout": 60,
+  "webhook_url": "https://seu-servidor-de-alertas.exemplo.com/ecac"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31.0
+Flask>=2.3.0

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,0 +1,218 @@
+:root {
+  --card-shadow: 0 15px 35px rgba(10, 10, 10, 0.1);
+}
+
+.hero-compact {
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.hero-dashboard .hero-body {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+.stat-card {
+  background: linear-gradient(135deg, #3273dc, #23d160);
+  border-radius: 12px;
+  box-shadow: var(--card-shadow);
+  color: #fff;
+  padding: 1.75rem;
+  height: 100%;
+}
+
+.stat-card.is-secondary {
+  background: linear-gradient(135deg, #00c4a7, #209cee);
+}
+
+.stat-card.is-danger {
+  background: linear-gradient(135deg, #ff3860, #ff9f43);
+}
+
+.stat-card .stat-title {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.75rem;
+  opacity: 0.9;
+}
+
+.stat-card .stat-value {
+  font-size: 2.5rem;
+  font-weight: 700;
+}
+
+.stat-card .stat-footnote {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.notifications-stack > .notification + .notification {
+  margin-top: 0.75rem;
+}
+
+.dashboard-card {
+  border-radius: 12px;
+  box-shadow: var(--card-shadow);
+}
+
+.dashboard-card .card-header {
+  border-bottom: none;
+}
+
+.dashboard-card .card-content {
+  padding: 1.5rem;
+}
+
+.timeline {
+  position: relative;
+  padding-left: 1.75rem;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  left: 0.55rem;
+  width: 2px;
+  background: linear-gradient(180deg, #3273dc, rgba(50, 115, 220, 0));
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 1.75rem;
+}
+
+.timeline-item:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-marker {
+  position: absolute;
+  left: -1.5rem;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background-color: #3273dc;
+  box-shadow: 0 0 0 4px rgba(50, 115, 220, 0.15);
+  top: 0.35rem;
+}
+
+.timeline-content {
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: var(--card-shadow);
+  padding: 1.25rem 1.5rem;
+}
+
+.timeline-content .heading {
+  color: #7a7a7a;
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
+}
+
+.timeline-content .title {
+  margin-bottom: 0.5rem;
+}
+
+.timeline-content .tag + .tag {
+  margin-left: 0.5rem;
+}
+
+.payload-preview {
+  background: #0a0a0a;
+  border-radius: 8px;
+  color: #f5f5f5;
+  padding: 1rem;
+  overflow: auto;
+}
+
+.payload-preview code,
+.payload-preview pre {
+  background: transparent;
+  color: inherit;
+  font-family: "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-size: 0.85rem;
+}
+
+.quick-actions .button {
+  margin-bottom: 0.5rem;
+  width: 100%;
+}
+
+.quick-actions form {
+  width: 100%;
+}
+
+.quick-actions form .button {
+  width: 100%;
+}
+
+.meta-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.meta-list li + li {
+  margin-top: 0.5rem;
+}
+
+.meta-list strong {
+  display: inline-block;
+  min-width: 120px;
+}
+
+.empty-state {
+  align-items: center;
+  border: 2px dashed #b5b5b5;
+  border-radius: 10px;
+  display: flex;
+  justify-content: center;
+  min-height: 160px;
+  padding: 2rem;
+  text-align: center;
+}
+
+.details-block {
+  border-radius: 12px;
+  box-shadow: var(--card-shadow);
+  padding: 1.5rem;
+}
+
+.details-block + .details-block {
+  margin-top: 1.5rem;
+}
+
+.details-block h3 {
+  margin-bottom: 1rem;
+}
+
+.raw-status details {
+  margin-top: 1rem;
+}
+
+.raw-status summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .stat-card {
+    margin-bottom: 1.25rem;
+  }
+
+  .quick-actions .button {
+    margin-bottom: 0.75rem;
+  }
+
+  .timeline::before {
+    left: 0.35rem;
+  }
+
+  .timeline-marker {
+    left: -1.75rem;
+  }
+}

--- a/templates/add_client.html
+++ b/templates/add_client.html
@@ -1,61 +1,91 @@
 {% extends 'base.html' %}
 {% block title %}Novo cliente - Monitor eCAC{% endblock %}
+
+{% block hero %}
+<section class="hero is-success hero-compact">
+  <div class="hero-body">
+    <div class="container">
+      <p class="title">Cadastrar novo cliente</p>
+      <p class="subtitle">Informe os dados do certificado e as credenciais de procuração para habilitar o monitoramento automático.</p>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
 {% block content %}
-<form action="{{ url_for('create_client') }}" method="post" class="box">
-  <div class="field">
-    <label class="label">Documento</label>
-    <div class="control">
-      <input class="input" type="text" name="document" required placeholder="CPF ou CNPJ">
-    </div>
-  </div>
-  <div class="field">
-    <label class="label">Nome / Razão Social</label>
-    <div class="control">
-      <input class="input" type="text" name="name" required>
-    </div>
-  </div>
-  <div class="field">
-    <label class="label">Tipo</label>
-    <div class="control">
-      <div class="select">
-        <select name="client_type" required>
-          <option value="PJ">Pessoa Jurídica</option>
-          <option value="PF">Pessoa Física</option>
-        </select>
+<div class="columns is-variable is-6">
+  <div class="column is-two-thirds">
+    <form action="{{ url_for('create_client') }}" method="post" class="box">
+      <div class="field">
+        <label class="label">Documento</label>
+        <div class="control">
+          <input class="input" type="text" name="document" required placeholder="CPF ou CNPJ">
+        </div>
       </div>
+      <div class="field">
+        <label class="label">Nome / Razão Social</label>
+        <div class="control">
+          <input class="input" type="text" name="name" required>
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Tipo de cliente</label>
+        <div class="control">
+          <div class="select is-fullwidth">
+            <select name="client_type" required>
+              <option value="PJ">Pessoa Jurídica</option>
+              <option value="PF">Pessoa Física</option>
+            </select>
+          </div>
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Certificado (arquivo PEM)</label>
+        <div class="control">
+          <input class="input" type="text" name="certificate" required placeholder="/caminho/certificado.pem">
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Chave privada (arquivo PEM)</label>
+        <div class="control">
+          <input class="input" type="text" name="key" required placeholder="/caminho/chave.pem">
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Senha do certificado</label>
+        <div class="control">
+          <input class="input" type="password" name="certificate_password" placeholder="Opcional">
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Token de procuração específica</label>
+        <div class="control">
+          <input class="input" type="text" name="procuracao_token" placeholder="Opcional">
+        </div>
+      </div>
+      <div class="field is-grouped">
+        <div class="control">
+          <button class="button is-link" type="submit">Salvar cliente</button>
+        </div>
+        <div class="control">
+          <a class="button is-light" href="{{ url_for('index') }}">Cancelar</a>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div class="column is-one-third">
+    <div class="details-block">
+      <h3 class="title is-5">Dicas importantes</h3>
+      <ul class="meta-list">
+        <li><strong>Certificado:</strong> utilize arquivos no formato PEM já convertidos a partir do A1.</li>
+        <li><strong>Permissões:</strong> valide se o contador possui procuração eletrônica ativa no eCAC.</li>
+        <li><strong>Ambiente:</strong> mantenha os arquivos em diretório seguro e com permissões restritas.</li>
+      </ul>
+    </div>
+    <div class="details-block" style="margin-top: 1.5rem;">
+      <h3 class="title is-5">Próximos passos</h3>
+      <p class="is-size-6">Após salvar o cliente, execute um ciclo manual para validar a comunicação com a API e revisar os eventos iniciais.</p>
     </div>
   </div>
-  <div class="field">
-    <label class="label">Certificado (PEM)</label>
-    <div class="control">
-      <input class="input" type="text" name="certificate" required placeholder="/caminho/cert.pem">
-    </div>
-  </div>
-  <div class="field">
-    <label class="label">Chave privada (PEM)</label>
-    <div class="control">
-      <input class="input" type="text" name="key" required placeholder="/caminho/key.pem">
-    </div>
-  </div>
-  <div class="field">
-    <label class="label">Senha do certificado</label>
-    <div class="control">
-      <input class="input" type="password" name="certificate_password" placeholder="Opcional">
-    </div>
-  </div>
-  <div class="field">
-    <label class="label">Token de procuração específico</label>
-    <div class="control">
-      <input class="input" type="text" name="procuracao_token" placeholder="Opcional">
-    </div>
-  </div>
-  <div class="field is-grouped">
-    <div class="control">
-      <button class="button is-link" type="submit">Salvar</button>
-    </div>
-    <div class="control">
-      <a class="button is-light" href="{{ url_for('index') }}">Cancelar</a>
-    </div>
-  </div>
-</form>
+</div>
 {% endblock %}

--- a/templates/add_client.html
+++ b/templates/add_client.html
@@ -1,0 +1,61 @@
+{% extends 'base.html' %}
+{% block title %}Novo cliente - Monitor eCAC{% endblock %}
+{% block content %}
+<form action="{{ url_for('create_client') }}" method="post" class="box">
+  <div class="field">
+    <label class="label">Documento</label>
+    <div class="control">
+      <input class="input" type="text" name="document" required placeholder="CPF ou CNPJ">
+    </div>
+  </div>
+  <div class="field">
+    <label class="label">Nome / Razão Social</label>
+    <div class="control">
+      <input class="input" type="text" name="name" required>
+    </div>
+  </div>
+  <div class="field">
+    <label class="label">Tipo</label>
+    <div class="control">
+      <div class="select">
+        <select name="client_type" required>
+          <option value="PJ">Pessoa Jurídica</option>
+          <option value="PF">Pessoa Física</option>
+        </select>
+      </div>
+    </div>
+  </div>
+  <div class="field">
+    <label class="label">Certificado (PEM)</label>
+    <div class="control">
+      <input class="input" type="text" name="certificate" required placeholder="/caminho/cert.pem">
+    </div>
+  </div>
+  <div class="field">
+    <label class="label">Chave privada (PEM)</label>
+    <div class="control">
+      <input class="input" type="text" name="key" required placeholder="/caminho/key.pem">
+    </div>
+  </div>
+  <div class="field">
+    <label class="label">Senha do certificado</label>
+    <div class="control">
+      <input class="input" type="password" name="certificate_password" placeholder="Opcional">
+    </div>
+  </div>
+  <div class="field">
+    <label class="label">Token de procuração específico</label>
+    <div class="control">
+      <input class="input" type="text" name="procuracao_token" placeholder="Opcional">
+    </div>
+  </div>
+  <div class="field is-grouped">
+    <div class="control">
+      <button class="button is-link" type="submit">Salvar</button>
+    </div>
+    <div class="control">
+      <a class="button is-light" href="{{ url_for('index') }}">Cancelar</a>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,24 +4,113 @@
     <meta charset="utf-8">
     <title>{% block title %}Monitor eCAC{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"
+    >
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      integrity="sha512-SzlrxWriC3xO3c6t1QXSf56Z3V1LdgY6sM1U9wNXjwELyhlHLLJoPLD114F8C1ZySb9p8Anynw6L9X9+YxFeg=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    >
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
   </head>
   <body>
-    <section class="section">
+    <nav class="navbar is-dark" role="navigation" aria-label="main navigation">
+      <div class="navbar-brand">
+        <a class="navbar-item has-text-weight-semibold" href="{{ url_for('index') }}">
+          <span class="icon-text">
+            <span class="icon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="currentColor">
+                <path d="M12 3a9 9 0 1 0 9 9 9.01 9.01 0 0 0-9-9Zm0 16a7 7 0 1 1 7-7 7.01 7.01 0 0 1-7 7Zm1-7h3v2h-5V7h2Z" />
+              </svg>
+            </span>
+            <span>Monitor eCAC</span>
+          </span>
+        </a>
+        <a
+          role="button"
+          class="navbar-burger"
+          aria-label="menu"
+          aria-expanded="false"
+          data-target="navbarMain"
+        >
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+        </a>
+      </div>
+      <div id="navbarMain" class="navbar-menu">
+        <div class="navbar-start">
+          <a class="navbar-item" href="{{ url_for('index') }}">Painel</a>
+          <a class="navbar-item" href="{{ url_for('new_client') }}">Cadastrar cliente</a>
+        </div>
+        <div class="navbar-end">
+          <div class="navbar-item">
+            {% if config_available %}
+              <span class="tag is-success is-light">
+                Configuração carregada
+              </span>
+            {% else %}
+              <span class="tag is-warning is-light">
+                Configuração não encontrada
+              </span>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    {% block hero %}
+    <section class="hero is-primary hero-compact">
+      <div class="hero-body">
+        <div class="container">
+          <p class="title">Monitoramento do eCAC</p>
+          <p class="subtitle">Controle centralizado das notificações fiscais dos clientes.</p>
+        </div>
+      </div>
+    </section>
+    {% endblock %}
+
+    <main class="section">
       <div class="container">
-        <h1 class="title">Monitoramento do eCAC</h1>
-        <p class="subtitle">Controle clientes, execute ciclos e visualize obrigações.</p>
         {% with messages = get_flashed_messages(with_categories=true) %}
           {% if messages %}
-            {% for category, message in messages %}
-              <div class="notification is-{{ 'danger' if category == 'error' else category }}">
-                {{ message }}
-              </div>
-            {% endfor %}
+            <div class="notifications-stack">
+              {% for category, message in messages %}
+                <div class="notification is-{{ 'danger' if category == 'error' else category }}">
+                  {{ message }}
+                </div>
+              {% endfor %}
+            </div>
           {% endif %}
         {% endwith %}
         {% block content %}{% endblock %}
       </div>
-    </section>
+    </main>
+
+    <footer class="footer">
+      <div class="content has-text-centered">
+        <p>
+          <strong>Monitor eCAC</strong> — Automação completa para escritórios de contabilidade.
+          Utilize este painel para acompanhar certificados, obrigações e alertas em tempo real.
+        </p>
+      </div>
+    </footer>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const burgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
+        burgers.forEach((el) => {
+          el.addEventListener('click', () => {
+            const target = el.dataset.target;
+            const $target = document.getElementById(target);
+            el.classList.toggle('is-active');
+            $target.classList.toggle('is-active');
+          });
+        });
+      });
+    </script>
   </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8">
+    <title>{% block title %}Monitor eCAC{% endblock %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+  </head>
+  <body>
+    <section class="section">
+      <div class="container">
+        <h1 class="title">Monitoramento do eCAC</h1>
+        <p class="subtitle">Controle clientes, execute ciclos e visualize obrigações.</p>
+        {% with messages = get_flashed_messages(with_categories=true) %}
+          {% if messages %}
+            {% for category, message in messages %}
+              <div class="notification is-{{ 'danger' if category == 'error' else category }}">
+                {{ message }}
+              </div>
+            {% endfor %}
+          {% endif %}
+        {% endwith %}
+        {% block content %}{% endblock %}
+      </div>
+    </section>
+  </body>
+</html>

--- a/templates/client_detail.html
+++ b/templates/client_detail.html
@@ -1,73 +1,138 @@
 {% extends 'base.html' %}
 {% block title %}{{ client.name }} - Monitor eCAC{% endblock %}
-{% block content %}
-<div class="buttons">
-  <a class="button is-light" href="{{ url_for('index') }}">&larr; Voltar</a>
-  <a class="button is-info" href="{{ url_for('client_events', document=client.document) }}">Histórico de eventos</a>
-  <a class="button is-warning" href="{{ url_for('edit_client', document=client.document) }}">Editar</a>
-  <form action="{{ url_for('run_cycle_for_client', document=client.document) }}" method="post" style="display:inline;">
-    <button class="button is-primary" type="submit" {% if not config_available %}disabled{% endif %}>Rodar ciclo agora</button>
-  </form>
-  <form action="{{ url_for('delete_client', document=client.document) }}" method="post" style="display:inline;" onsubmit="return confirm('Deseja remover este cliente e seu histórico?');">
-    <button class="button is-danger" type="submit">Excluir</button>
-  </form>
-</div>
-<div class="box" style="margin-top:1.5rem;">
-  <h2 class="title is-4">{{ client.name }}</h2>
-  <p><strong>Documento:</strong> {{ client.document }}</p>
-  <p><strong>Tipo:</strong> {{ client.client_type }}</p>
-  <p><strong>Certificado:</strong> {{ client.certificate_path }}</p>
-  <p><strong>Chave:</strong> {{ client.key_path }}</p>
-  <p><strong>Última verificação:</strong> {{ client.last_checked.isoformat() if client.last_checked else 'nunca' }}</p>
-</div>
-{% if status %}
-  {% if status.notifications %}
-    <h3 class="title is-5">Notificações recentes</h3>
-    <table class="table is-fullwidth is-striped">
-      <thead>
-        <tr>
-          <th>#</th>
-          <th>Conteúdo</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for notif in status.notifications %}
-          <tr>
-            <td>{{ loop.index }}</td>
-            <td><pre>{{ notif | tojson(indent=2) }}</pre></td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  {% endif %}
-  {% if status.obligations %}
-    <h3 class="title is-5">Obrigações em aberto</h3>
-    <table class="table is-fullwidth is-hoverable">
-      <thead>
-        <tr>
-          <th>#</th>
-          <th>Detalhes</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for obligation in status.obligations %}
-          <tr>
-            <td>{{ loop.index }}</td>
-            <td><pre>{{ obligation | tojson(indent=2) }}</pre></td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  {% endif %}
-  {% if status.raw %}
-    <article class="message is-warning">
-      <div class="message-header">Status bruto</div>
-      <div class="message-body">
-        <pre>{{ status.raw }}</pre>
+
+{% block hero %}
+<section class="hero is-info hero-compact">
+  <div class="hero-body">
+    <div class="container">
+      <p class="title">{{ client.name }}</p>
+      <p class="subtitle">{{ client.document }} · {{ 'Empresa' if client.client_type == 'PJ' else 'Pessoa Física' }}</p>
+      <div class="tags">
+        <span class="tag is-light">Última verificação:
+          {% if client.last_checked %}
+            {{ client.last_checked.strftime('%d/%m/%Y %H:%M') }}
+          {% else %}
+            nunca
+          {% endif %}
+        </span>
       </div>
-    </article>
-  {% endif %}
-{% else %}
-  <p>Nenhum status registrado ainda. Execute um ciclo.</p>
-{% endif %}
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<div class="columns is-variable is-6">
+  <div class="column is-two-thirds">
+    <div class="details-block">
+      <h3 class="title is-5">Dados do cadastro</h3>
+      <p><strong>Documento:</strong> {{ client.document }}</p>
+      <p><strong>Tipo:</strong> {{ 'Pessoa Jurídica' if client.client_type == 'PJ' else 'Pessoa Física' }}</p>
+      <p><strong>Caminho do certificado:</strong> <code>{{ client.certificate_path }}</code></p>
+      <p><strong>Caminho da chave privada:</strong> <code>{{ client.key_path }}</code></p>
+      <p><strong>Token específico de procuração:</strong> {{ client.procuracao_token or 'não informado' }}</p>
+    </div>
+
+    <div class="details-block" style="margin-top: 1.5rem;">
+      <h3 class="title is-5">Status do monitoramento</h3>
+      {% if status %}
+        <div class="columns">
+          <div class="column">
+            <h4 class="title is-6">Notificações</h4>
+            {% if notifications %}
+              <ul class="meta-list">
+                {% for item in notifications %}
+                  <li>
+                    <strong>#{{ loop.index }}</strong>
+                    <div class="is-size-7">{{ (item.title or item.titulo or item.assunto or item.subject) if item is mapping else item }}</div>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              <p class="has-text-grey">Nenhuma notificação registrada.</p>
+            {% endif %}
+          </div>
+          <div class="column">
+            <h4 class="title is-6">Obrigações pendentes</h4>
+            {% if obligations %}
+              <ul class="meta-list">
+                {% for obligation in obligations %}
+                  <li>
+                    <strong>#{{ loop.index }}</strong>
+                    <div class="is-size-7">
+                      {{ (obligation.title or obligation.titulo or obligation.descricao) if obligation is mapping else obligation }}
+                    </div>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              <p class="has-text-grey">Nenhuma obrigação pendente.</p>
+            {% endif %}
+          </div>
+        </div>
+        {% if metadata %}
+          <div class="details-block" style="margin-top: 1rem;">
+            <h4 class="title is-6">Metadados</h4>
+            <ul class="meta-list">
+              {% for key, value in metadata.items() %}
+                <li><strong>{{ key }}:</strong> {{ value }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+        <div class="raw-status">
+          <details>
+            <summary>Exibir payload bruto retornado pela API</summary>
+            <div class="payload-preview" style="margin-top: 1rem;">
+              <pre><code>{{ status | tojson(indent=2, ensure_ascii=False) if status is mapping else status }}</code></pre>
+            </div>
+          </details>
+        </div>
+      {% else %}
+        <p class="has-text-grey">Nenhum status registrado. Execute um ciclo para obter informações atualizadas.</p>
+      {% endif %}
+    </div>
+  </div>
+
+  <div class="column is-one-third">
+    <div class="details-block quick-actions">
+      <h3 class="title is-5">Ações rápidas</h3>
+      <a class="button is-light" href="{{ url_for('index') }}">&larr; Voltar para o painel</a>
+      <a class="button is-info" href="{{ url_for('client_events', document=client.document) }}">Histórico de eventos</a>
+      <a class="button is-warning" href="{{ url_for('edit_client', document=client.document) }}">Editar cadastro</a>
+      <form action="{{ url_for('run_cycle_for_client', document=client.document) }}" method="post">
+        <button class="button is-primary" type="submit" {% if not config_available %}disabled{% endif %}>Rodar ciclo agora</button>
+      </form>
+      <form
+        action="{{ url_for('delete_client', document=client.document) }}"
+        method="post"
+        onsubmit="return confirm('Deseja remover este cliente e seu histórico?');"
+      >
+        <button class="button is-danger" type="submit">Excluir cliente</button>
+      </form>
+    </div>
+
+    <div class="details-block" style="margin-top: 1.5rem;">
+      <h3 class="title is-5">Últimos eventos</h3>
+      {% if recent_events %}
+        <ul class="meta-list">
+          {% for event in recent_events %}
+            <li>
+              <strong>{{ event.summary }}</strong>
+              <div class="is-size-7 has-text-grey">{{ event.received_at.strftime('%d/%m/%Y %H:%M') }}</div>
+              {% if event.description %}
+                <div class="is-size-7">{{ event.description }}</div>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+        <div class="has-text-centered" style="margin-top: 0.75rem;">
+          <a class="button is-small is-light" href="{{ url_for('client_events', document=client.document) }}">Ver histórico completo</a>
+        </div>
+      {% else %}
+        <p class="has-text-grey">Nenhum evento registrado para este cliente.</p>
+      {% endif %}
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/templates/client_detail.html
+++ b/templates/client_detail.html
@@ -1,0 +1,73 @@
+{% extends 'base.html' %}
+{% block title %}{{ client.name }} - Monitor eCAC{% endblock %}
+{% block content %}
+<div class="buttons">
+  <a class="button is-light" href="{{ url_for('index') }}">&larr; Voltar</a>
+  <a class="button is-info" href="{{ url_for('client_events', document=client.document) }}">Histórico de eventos</a>
+  <a class="button is-warning" href="{{ url_for('edit_client', document=client.document) }}">Editar</a>
+  <form action="{{ url_for('run_cycle_for_client', document=client.document) }}" method="post" style="display:inline;">
+    <button class="button is-primary" type="submit" {% if not config_available %}disabled{% endif %}>Rodar ciclo agora</button>
+  </form>
+  <form action="{{ url_for('delete_client', document=client.document) }}" method="post" style="display:inline;" onsubmit="return confirm('Deseja remover este cliente e seu histórico?');">
+    <button class="button is-danger" type="submit">Excluir</button>
+  </form>
+</div>
+<div class="box" style="margin-top:1.5rem;">
+  <h2 class="title is-4">{{ client.name }}</h2>
+  <p><strong>Documento:</strong> {{ client.document }}</p>
+  <p><strong>Tipo:</strong> {{ client.client_type }}</p>
+  <p><strong>Certificado:</strong> {{ client.certificate_path }}</p>
+  <p><strong>Chave:</strong> {{ client.key_path }}</p>
+  <p><strong>Última verificação:</strong> {{ client.last_checked.isoformat() if client.last_checked else 'nunca' }}</p>
+</div>
+{% if status %}
+  {% if status.notifications %}
+    <h3 class="title is-5">Notificações recentes</h3>
+    <table class="table is-fullwidth is-striped">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Conteúdo</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for notif in status.notifications %}
+          <tr>
+            <td>{{ loop.index }}</td>
+            <td><pre>{{ notif | tojson(indent=2) }}</pre></td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+  {% if status.obligations %}
+    <h3 class="title is-5">Obrigações em aberto</h3>
+    <table class="table is-fullwidth is-hoverable">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Detalhes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for obligation in status.obligations %}
+          <tr>
+            <td>{{ loop.index }}</td>
+            <td><pre>{{ obligation | tojson(indent=2) }}</pre></td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+  {% if status.raw %}
+    <article class="message is-warning">
+      <div class="message-header">Status bruto</div>
+      <div class="message-body">
+        <pre>{{ status.raw }}</pre>
+      </div>
+    </article>
+  {% endif %}
+{% else %}
+  <p>Nenhum status registrado ainda. Execute um ciclo.</p>
+{% endif %}
+{% endblock %}

--- a/templates/client_events.html
+++ b/templates/client_events.html
@@ -1,42 +1,111 @@
 {% extends 'base.html' %}
 {% block title %}Eventos de {{ client.name }} - Monitor eCAC{% endblock %}
+
+{% block hero %}
+<section class="hero is-link hero-compact">
+  <div class="hero-body">
+    <div class="container">
+      <p class="title">Histórico de eventos</p>
+      <p class="subtitle">{{ client.name }} · {{ client.document }}</p>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
 {% block content %}
-<div class="buttons">
-  <a class="button is-light" href="{{ url_for('client_detail', document=client.document) }}">&larr; Voltar para detalhes</a>
-  <a class="button" href="{{ url_for('client_events', document=client.document, limit=limit, offset=offset) }}">Atualizar</a>
+<div class="columns is-variable is-6">
+  <div class="column is-three-quarters">
+    <div class="details-block">
+      <div class="level">
+        <div class="level-left">
+          <div class="level-item">
+            <h3 class="title is-5">Linha do tempo</h3>
+          </div>
+        </div>
+        <div class="level-right">
+          <div class="buttons are-small">
+            <a class="button is-light" href="{{ url_for('client_detail', document=client.document) }}">&larr; Voltar</a>
+            <a class="button is-info" href="{{ url_for('client_events', document=client.document, limit=limit, offset=offset) }}">Atualizar</a>
+          </div>
+        </div>
+      </div>
+      {% if events %}
+        <div class="timeline">
+          {% for event in events %}
+            <div class="timeline-item">
+              <div class="timeline-marker"></div>
+              <div class="timeline-content">
+                <p class="heading">{{ event.received_at.strftime('%d/%m/%Y %H:%M:%S') }}</p>
+                <p class="title is-5">{{ event.summary }}</p>
+                <div class="tags">
+                  {% if event.category %}
+                    <span class="tag is-info is-light">{{ event.category }}</span>
+                  {% endif %}
+                  {% if event.reference %}
+                    <span class="tag is-light">Ref: {{ event.reference }}</span>
+                  {% endif %}
+                  <span class="tag is-light">ID {{ event.id }}</span>
+                </div>
+                {% if event.description %}
+                  <p style="margin-top: 0.5rem;">{{ event.description }}</p>
+                {% endif %}
+                <details style="margin-top: 1rem;">
+                  <summary>Ver payload bruto</summary>
+                  <div class="payload-preview" style="margin-top: 0.75rem;">
+                    <pre><code>{{ event.payload | tojson(indent=2, ensure_ascii=False) }}</code></pre>
+                  </div>
+                </details>
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+        <div class="buttons" style="margin-top: 1.5rem;">
+          {% if prev_offset is not none %}
+            <a class="button" href="{{ url_for('client_events', document=client.document, limit=limit, offset=prev_offset) }}">&larr; Anteriores</a>
+          {% endif %}
+          {% if next_offset is not none %}
+            <a class="button" href="{{ url_for('client_events', document=client.document, limit=limit, offset=next_offset) }}">Próximos &rarr;</a>
+          {% endif %}
+        </div>
+      {% else %}
+        <div class="empty-state">
+          <div>
+            <p class="title is-5">Nenhum evento registrado até o momento.</p>
+            <p class="subtitle is-6">Execute um ciclo de monitoramento para captar novas notificações.</p>
+          </div>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+  <div class="column is-one-quarter">
+    <div class="details-block">
+      <h3 class="title is-6">Configurações de exibição</h3>
+      <form action="{{ url_for('client_events', document=client.document) }}" method="get">
+        <div class="field">
+          <label class="label">Eventos por página</label>
+          <div class="control">
+            <div class="select is-fullwidth">
+              <select name="limit">
+                {% for option in [10, 25, 50, 100] %}
+                  <option value="{{ option }}" {% if option == limit %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="field">
+          <label class="label">Iniciar em</label>
+          <div class="control">
+            <input class="input" type="number" name="offset" value="{{ offset }}" min="0">
+          </div>
+        </div>
+        <div class="field">
+          <div class="control">
+            <button class="button is-primary is-fullwidth" type="submit">Aplicar filtros</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
 </div>
-<div class="box">
-  <h2 class="title is-4">Histórico de eventos</h2>
-  <p><strong>Cliente:</strong> {{ client.name }} ({{ client.document }})</p>
-</div>
-{% if events %}
-<table class="table is-fullwidth is-striped">
-  <thead>
-    <tr>
-      <th>ID</th>
-      <th>Recebido em</th>
-      <th>Conteúdo</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for event in events %}
-    <tr>
-      <td>{{ event.id }}</td>
-      <td>{{ event.received_at.isoformat() }}</td>
-      <td><pre>{{ event.payload | tojson(indent=2) }}</pre></td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
-<div class="buttons">
-  {% if offset - limit >= 0 %}
-    <a class="button" href="{{ url_for('client_events', document=client.document, limit=limit, offset=offset - limit) }}">&larr; Anteriores</a>
-  {% endif %}
-  {% if events|length == limit %}
-    <a class="button" href="{{ url_for('client_events', document=client.document, limit=limit, offset=offset + limit) }}">Próximos &rarr;</a>
-  {% endif %}
-</div>
-{% else %}
-  <p>Nenhum evento registrado para este cliente.</p>
-{% endif %}
 {% endblock %}

--- a/templates/client_events.html
+++ b/templates/client_events.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% block title %}Eventos de {{ client.name }} - Monitor eCAC{% endblock %}
+{% block content %}
+<div class="buttons">
+  <a class="button is-light" href="{{ url_for('client_detail', document=client.document) }}">&larr; Voltar para detalhes</a>
+  <a class="button" href="{{ url_for('client_events', document=client.document, limit=limit, offset=offset) }}">Atualizar</a>
+</div>
+<div class="box">
+  <h2 class="title is-4">Histórico de eventos</h2>
+  <p><strong>Cliente:</strong> {{ client.name }} ({{ client.document }})</p>
+</div>
+{% if events %}
+<table class="table is-fullwidth is-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Recebido em</th>
+      <th>Conteúdo</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for event in events %}
+    <tr>
+      <td>{{ event.id }}</td>
+      <td>{{ event.received_at.isoformat() }}</td>
+      <td><pre>{{ event.payload | tojson(indent=2) }}</pre></td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<div class="buttons">
+  {% if offset - limit >= 0 %}
+    <a class="button" href="{{ url_for('client_events', document=client.document, limit=limit, offset=offset - limit) }}">&larr; Anteriores</a>
+  {% endif %}
+  {% if events|length == limit %}
+    <a class="button" href="{{ url_for('client_events', document=client.document, limit=limit, offset=offset + limit) }}">Próximos &rarr;</a>
+  {% endif %}
+</div>
+{% else %}
+  <p>Nenhum evento registrado para este cliente.</p>
+{% endif %}
+{% endblock %}

--- a/templates/edit_client.html
+++ b/templates/edit_client.html
@@ -1,0 +1,61 @@
+{% extends 'base.html' %}
+{% block title %}Editar {{ client.name }} - Monitor eCAC{% endblock %}
+{% block content %}
+<form action="{{ url_for('update_client', document=client.document) }}" method="post" class="box">
+  <div class="field">
+    <label class="label">Documento</label>
+    <div class="control">
+      <input class="input" type="text" value="{{ client.document }}" disabled>
+    </div>
+  </div>
+  <div class="field">
+    <label class="label">Nome / Razão Social</label>
+    <div class="control">
+      <input class="input" type="text" name="name" value="{{ client.name }}" required>
+    </div>
+  </div>
+  <div class="field">
+    <label class="label">Tipo</label>
+    <div class="control">
+      <div class="select">
+        <select name="client_type" required>
+          <option value="PJ" {% if client.client_type == 'PJ' %}selected{% endif %}>Pessoa Jurídica</option>
+          <option value="PF" {% if client.client_type == 'PF' %}selected{% endif %}>Pessoa Física</option>
+        </select>
+      </div>
+    </div>
+  </div>
+  <div class="field">
+    <label class="label">Certificado (PEM)</label>
+    <div class="control">
+      <input class="input" type="text" name="certificate" value="{{ client.certificate_path }}" required>
+    </div>
+  </div>
+  <div class="field">
+    <label class="label">Chave privada (PEM)</label>
+    <div class="control">
+      <input class="input" type="text" name="key" value="{{ client.key_path }}" required>
+    </div>
+  </div>
+  <div class="field">
+    <label class="label">Senha do certificado</label>
+    <div class="control">
+      <input class="input" type="password" name="certificate_password" value="{{ client.certificate_password or '' }}" placeholder="Opcional">
+    </div>
+  </div>
+  <div class="field">
+    <label class="label">Token de procuração específico</label>
+    <div class="control">
+      <input class="input" type="text" name="procuracao_token" value="{{ client.procuracao_token or '' }}" placeholder="Opcional">
+    </div>
+  </div>
+  <div class="field is-grouped">
+    <div class="control">
+      <button class="button is-link" type="submit">Salvar alterações</button>
+    </div>
+    <div class="control">
+      <a class="button is-light" href="{{ url_for('client_detail', document=client.document) }}">Cancelar</a>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/templates/edit_client.html
+++ b/templates/edit_client.html
@@ -1,61 +1,89 @@
 {% extends 'base.html' %}
 {% block title %}Editar {{ client.name }} - Monitor eCAC{% endblock %}
+
+{% block hero %}
+<section class="hero is-warning hero-compact">
+  <div class="hero-body">
+    <div class="container">
+      <p class="title">Atualizar cadastro</p>
+      <p class="subtitle">Faça ajustes de certificados, senhas e tokens sempre que houver troca de representantes ou renovação.</p>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
 {% block content %}
-<form action="{{ url_for('update_client', document=client.document) }}" method="post" class="box">
-  <div class="field">
-    <label class="label">Documento</label>
-    <div class="control">
-      <input class="input" type="text" value="{{ client.document }}" disabled>
-    </div>
-  </div>
-  <div class="field">
-    <label class="label">Nome / Razão Social</label>
-    <div class="control">
-      <input class="input" type="text" name="name" value="{{ client.name }}" required>
-    </div>
-  </div>
-  <div class="field">
-    <label class="label">Tipo</label>
-    <div class="control">
-      <div class="select">
-        <select name="client_type" required>
-          <option value="PJ" {% if client.client_type == 'PJ' %}selected{% endif %}>Pessoa Jurídica</option>
-          <option value="PF" {% if client.client_type == 'PF' %}selected{% endif %}>Pessoa Física</option>
-        </select>
+<div class="columns is-variable is-6">
+  <div class="column is-two-thirds">
+    <form action="{{ url_for('update_client', document=client.document) }}" method="post" class="box">
+      <div class="field">
+        <label class="label">Documento</label>
+        <p class="control"><input class="input" type="text" value="{{ client.document }}" disabled></p>
       </div>
+      <div class="field">
+        <label class="label">Nome / Razão Social</label>
+        <div class="control">
+          <input class="input" type="text" name="name" value="{{ client.name }}" required>
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Tipo de cliente</label>
+        <div class="control">
+          <div class="select is-fullwidth">
+            <select name="client_type" required>
+              <option value="PJ" {% if client.client_type == 'PJ' %}selected{% endif %}>Pessoa Jurídica</option>
+              <option value="PF" {% if client.client_type == 'PF' %}selected{% endif %}>Pessoa Física</option>
+            </select>
+          </div>
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Certificado (arquivo PEM)</label>
+        <div class="control">
+          <input class="input" type="text" name="certificate" value="{{ client.certificate_path }}" required>
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Chave privada (arquivo PEM)</label>
+        <div class="control">
+          <input class="input" type="text" name="key" value="{{ client.key_path }}" required>
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Senha do certificado</label>
+        <div class="control">
+          <input class="input" type="password" name="certificate_password" value="{{ client.certificate_password or '' }}" placeholder="Opcional">
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Token de procuração específica</label>
+        <div class="control">
+          <input class="input" type="text" name="procuracao_token" value="{{ client.procuracao_token or '' }}" placeholder="Opcional">
+        </div>
+      </div>
+      <div class="field is-grouped">
+        <div class="control">
+          <button class="button is-link" type="submit">Salvar alterações</button>
+        </div>
+        <div class="control">
+          <a class="button is-light" href="{{ url_for('client_detail', document=client.document) }}">Cancelar</a>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div class="column is-one-third">
+    <div class="details-block">
+      <h3 class="title is-5">Boas práticas</h3>
+      <ul class="meta-list">
+        <li>Atualize o certificado sempre que o arquivo for substituído ou expirar.</li>
+        <li>Ao remover a senha, deixe o campo em branco e salve.</li>
+        <li>O token de procuração pode ser individual para o cliente ou o padrão definido no arquivo de configuração.</li>
+      </ul>
+    </div>
+    <div class="details-block" style="margin-top: 1.5rem;">
+      <h3 class="title is-5">Monitoramento</h3>
+      <p class="is-size-6">Após salvar, execute um ciclo para validar o novo certificado e garantir que o escritório continue recebendo notificações.</p>
     </div>
   </div>
-  <div class="field">
-    <label class="label">Certificado (PEM)</label>
-    <div class="control">
-      <input class="input" type="text" name="certificate" value="{{ client.certificate_path }}" required>
-    </div>
-  </div>
-  <div class="field">
-    <label class="label">Chave privada (PEM)</label>
-    <div class="control">
-      <input class="input" type="text" name="key" value="{{ client.key_path }}" required>
-    </div>
-  </div>
-  <div class="field">
-    <label class="label">Senha do certificado</label>
-    <div class="control">
-      <input class="input" type="password" name="certificate_password" value="{{ client.certificate_password or '' }}" placeholder="Opcional">
-    </div>
-  </div>
-  <div class="field">
-    <label class="label">Token de procuração específico</label>
-    <div class="control">
-      <input class="input" type="text" name="procuracao_token" value="{{ client.procuracao_token or '' }}" placeholder="Opcional">
-    </div>
-  </div>
-  <div class="field is-grouped">
-    <div class="control">
-      <button class="button is-link" type="submit">Salvar alterações</button>
-    </div>
-    <div class="control">
-      <a class="button is-light" href="{{ url_for('client_detail', document=client.document) }}">Cancelar</a>
-    </div>
-  </div>
-</form>
+</div>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,68 @@
+{% extends 'base.html' %}
+{% block title %}Monitor eCAC{% endblock %}
+{% block content %}
+<div class="buttons">
+  <a class="button is-link" href="{{ url_for('new_client') }}">Cadastrar cliente</a>
+  <form action="{{ url_for('run_cycle') }}" method="post" style="display:inline;">
+    <button class="button is-primary" type="submit" {% if not config_available %}disabled{% endif %}>
+      Executar ciclo agora
+    </button>
+  </form>
+</div>
+{% if not config_available %}
+  <article class="message is-warning">
+    <div class="message-header">Configuração ausente</div>
+    <div class="message-body">
+      Defina a variável de ambiente <code>MONITOR_CONFIG</code> apontando para o arquivo JSON
+      de configuração antes de executar um ciclo.
+    </div>
+  </article>
+{% endif %}
+<table class="table is-fullwidth is-striped">
+  <thead>
+    <tr>
+      <th>Documento</th>
+      <th>Nome</th>
+      <th>Tipo</th>
+      <th>Última verificação</th>
+      <th>Avisos</th>
+      <th class="is-narrow">Ações</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for entry in clients %}
+      {% set client = entry.client %}
+      <tr>
+        <td><a href="{{ url_for('client_detail', document=client.document) }}">{{ client.document }}</a></td>
+        <td>{{ client.name }}</td>
+        <td>{{ client.client_type }}</td>
+        <td>{{ client.last_checked.isoformat() if client.last_checked else 'nunca' }}</td>
+        <td>
+          {% if entry.status and entry.status.notifications %}
+            {{ entry.status.notifications|length }} novas notificações
+          {% else %}
+            Nenhum evento
+          {% endif %}
+        </td>
+        <td>
+          <div class="buttons are-small">
+            <a class="button" href="{{ url_for('client_detail', document=client.document) }}">Detalhes</a>
+            <a class="button is-info" href="{{ url_for('client_events', document=client.document) }}">Eventos</a>
+            <a class="button is-warning" href="{{ url_for('edit_client', document=client.document) }}">Editar</a>
+            <form action="{{ url_for('run_cycle_for_client', document=client.document) }}" method="post" style="display:inline;">
+              <button class="button is-primary" type="submit" {% if not config_available %}disabled{% endif %}>Rodar ciclo</button>
+            </form>
+            <form action="{{ url_for('delete_client', document=client.document) }}" method="post" style="display:inline;" onsubmit="return confirm('Deseja remover este cliente e seu histórico?');">
+              <button class="button is-danger" type="submit">Excluir</button>
+            </form>
+          </div>
+        </td>
+      </tr>
+    {% else %}
+      <tr>
+        <td colspan="6">Nenhum cliente cadastrado.</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,68 +1,252 @@
 {% extends 'base.html' %}
-{% block title %}Monitor eCAC{% endblock %}
-{% block content %}
-<div class="buttons">
-  <a class="button is-link" href="{{ url_for('new_client') }}">Cadastrar cliente</a>
-  <form action="{{ url_for('run_cycle') }}" method="post" style="display:inline;">
-    <button class="button is-primary" type="submit" {% if not config_available %}disabled{% endif %}>
-      Executar ciclo agora
-    </button>
-  </form>
-</div>
-{% if not config_available %}
-  <article class="message is-warning">
-    <div class="message-header">Configuração ausente</div>
-    <div class="message-body">
-      Defina a variável de ambiente <code>MONITOR_CONFIG</code> apontando para o arquivo JSON
-      de configuração antes de executar um ciclo.
-    </div>
-  </article>
-{% endif %}
-<table class="table is-fullwidth is-striped">
-  <thead>
-    <tr>
-      <th>Documento</th>
-      <th>Nome</th>
-      <th>Tipo</th>
-      <th>Última verificação</th>
-      <th>Avisos</th>
-      <th class="is-narrow">Ações</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for entry in clients %}
-      {% set client = entry.client %}
-      <tr>
-        <td><a href="{{ url_for('client_detail', document=client.document) }}">{{ client.document }}</a></td>
-        <td>{{ client.name }}</td>
-        <td>{{ client.client_type }}</td>
-        <td>{{ client.last_checked.isoformat() if client.last_checked else 'nunca' }}</td>
-        <td>
-          {% if entry.status and entry.status.notifications %}
-            {{ entry.status.notifications|length }} novas notificações
-          {% else %}
-            Nenhum evento
-          {% endif %}
-        </td>
-        <td>
-          <div class="buttons are-small">
-            <a class="button" href="{{ url_for('client_detail', document=client.document) }}">Detalhes</a>
-            <a class="button is-info" href="{{ url_for('client_events', document=client.document) }}">Eventos</a>
-            <a class="button is-warning" href="{{ url_for('edit_client', document=client.document) }}">Editar</a>
-            <form action="{{ url_for('run_cycle_for_client', document=client.document) }}" method="post" style="display:inline;">
-              <button class="button is-primary" type="submit" {% if not config_available %}disabled{% endif %}>Rodar ciclo</button>
-            </form>
-            <form action="{{ url_for('delete_client', document=client.document) }}" method="post" style="display:inline;" onsubmit="return confirm('Deseja remover este cliente e seu histórico?');">
-              <button class="button is-danger" type="submit">Excluir</button>
+{% block title %}Painel - Monitor eCAC{% endblock %}
+
+{% block hero %}
+<section class="hero is-primary hero-dashboard">
+  <div class="hero-body">
+    <div class="container">
+      <div class="columns is-vcentered">
+        <div class="column is-7">
+          <p class="title">Painel operacional do Monitor eCAC</p>
+          <p class="subtitle">
+            Visualize rapidamente o status dos clientes, execute ciclos sob demanda e acompanhe
+            as últimas notificações recebidas pela integração com a API proprietária.
+          </p>
+          <div class="buttons">
+            <a class="button is-light" href="{{ url_for('new_client') }}">
+              <span class="icon"><i class="fas fa-user-plus"></i></span>
+              <span>Adicionar cliente</span>
+            </a>
+            <form action="{{ url_for('run_cycle') }}" method="post">
+              <button class="button is-warning" type="submit" {% if not config_available %}disabled{% endif %}>
+                <span class="icon"><i class="fas fa-sync-alt"></i></span>
+                <span>Executar ciclo global</span>
+              </button>
             </form>
           </div>
-        </td>
-      </tr>
-    {% else %}
-      <tr>
-        <td colspan="6">Nenhum cliente cadastrado.</td>
-      </tr>
-    {% endfor %}
-  </tbody>
-</table>
+        </div>
+        <div class="column is-5">
+          <div class="columns is-multiline">
+            <div class="column is-half">
+              <div class="stat-card">
+                <p class="stat-title">Clientes monitorados</p>
+                <p class="stat-value">{{ metrics.total_clients }}</p>
+                <p class="stat-footnote">{{ metrics.pj_clients }} PJ · {{ metrics.pf_clients }} PF</p>
+              </div>
+            </div>
+            <div class="column is-half">
+              <div class="stat-card is-secondary">
+                <p class="stat-title">Eventos registrados</p>
+                <p class="stat-value">{{ metrics.total_events }}</p>
+                <p class="stat-footnote">{{ metrics.clients_with_alerts }} clientes com alertas</p>
+              </div>
+            </div>
+            <div class="column is-half">
+              <div class="stat-card is-danger">
+                <p class="stat-title">Último ciclo</p>
+                <p class="stat-value">
+                  {% if metrics.last_check %}
+                    {{ metrics.last_check.strftime('%d/%m %H:%M') }}
+                  {% else %}
+                    --
+                  {% endif %}
+                </p>
+                <p class="stat-footnote">
+                  {% if metrics.last_event %}
+                    Último evento {{ metrics.last_event.strftime('%d/%m %H:%M') }}
+                  {% else %}
+                    Nenhum evento registrado
+                  {% endif %}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<div class="columns is-variable is-6">
+  <div class="column is-two-thirds">
+    {% if not config_available %}
+      <article class="message is-warning">
+        <div class="message-header">Configuração ausente</div>
+        <div class="message-body">
+          Defina a variável de ambiente <code>MONITOR_CONFIG</code> apontando para o arquivo JSON
+          de configuração antes de executar um ciclo. A interface continua disponível para gestão de clientes.
+        </div>
+      </article>
+    {% endif %}
+
+    <div class="card dashboard-card">
+      <header class="card-header">
+        <p class="card-header-title">Clientes cadastrados</p>
+        <div class="card-header-icon">
+          <span class="tag is-light">{{ clients|length }} registros</span>
+        </div>
+      </header>
+      <div class="card-content">
+        <div class="table-container">
+          <table class="table is-fullwidth is-striped is-hoverable">
+            <thead>
+              <tr>
+                <th>Cliente</th>
+                <th class="is-hidden-touch">Documento</th>
+                <th>Tipo</th>
+                <th>Última verificação</th>
+                <th>Alertas</th>
+                <th class="is-narrow">Ações</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for entry in clients %}
+                {% set client = entry.client %}
+                <tr>
+                  <td>
+                    <strong>{{ client.name }}</strong>
+                    <br class="is-hidden-desktop">
+                    <small class="is-hidden-desktop has-text-grey">{{ client.document }}</small>
+                  </td>
+                  <td class="is-hidden-touch">{{ client.document }}</td>
+                  <td>
+                    <span class="tag is-rounded {{ 'is-link' if client.client_type == 'PJ' else 'is-info' }}">
+                      {{ 'Empresa' if client.client_type == 'PJ' else 'Pessoa Física' }}
+                    </span>
+                  </td>
+                  <td>
+                    {% if client.last_checked %}
+                      {{ client.last_checked.strftime('%d/%m/%Y %H:%M') }}
+                    {% else %}
+                      <span class="has-text-grey">Nunca verificado</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if entry.notifications > 0 %}
+                      <span class="tag is-danger is-light">{{ entry.notifications }} notificações</span>
+                    {% else %}
+                      <span class="tag is-light">Sem alertas</span>
+                    {% endif %}
+                    {% if entry.obligations > 0 %}
+                      <span class="tag is-warning is-light">{{ entry.obligations }} obrigações</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    <div class="buttons are-small">
+                      <a class="button is-light" href="{{ url_for('client_detail', document=client.document) }}">Detalhes</a>
+                      <a class="button is-info is-light" href="{{ url_for('client_events', document=client.document) }}">Eventos</a>
+                      <a class="button is-warning is-light" href="{{ url_for('edit_client', document=client.document) }}">Editar</a>
+                      <form action="{{ url_for('run_cycle_for_client', document=client.document) }}" method="post">
+                        <button class="button is-primary" type="submit" {% if not config_available %}disabled{% endif %}>
+                          Rodar ciclo
+                        </button>
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+              {% else %}
+                <tr>
+                  <td colspan="6">
+                    <div class="empty-state">
+                      <div>
+                        <p class="title is-5">Nenhum cliente cadastrado ainda</p>
+                        <p class="subtitle is-6">Clique em “Adicionar cliente” para iniciar o monitoramento.</p>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="column is-one-third">
+    <div class="card dashboard-card">
+      <header class="card-header">
+        <p class="card-header-title">Últimos eventos</p>
+      </header>
+      <div class="card-content">
+        {% if recent_events %}
+          <ul class="meta-list">
+            {% for event in recent_events %}
+              <li>
+                <p class="has-text-weight-semibold">{{ event.summary }}</p>
+                <p class="is-size-7 has-text-grey">
+                  {{ event.received_at.strftime('%d/%m/%Y %H:%M') }} · {{ event.client_name or event.client_document }}
+                </p>
+                {% if event.description %}
+                  <p class="is-size-7">{{ event.description }}</p>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+          <div class="has-text-centered" style="margin-top: 1rem;">
+            <a class="button is-small is-light" href="{{ url_for('client_events', document=recent_events[0].client_document) }}">
+              Ver histórico completo
+            </a>
+          </div>
+        {% else %}
+          <p class="has-text-grey">Nenhum evento recebido até o momento.</p>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="card dashboard-card" style="margin-top: 1.5rem;">
+      <header class="card-header">
+        <p class="card-header-title">Clientes a verificar</p>
+      </header>
+      <div class="card-content">
+        {% if stale_clients %}
+          <ul class="meta-list">
+            {% for entry in stale_clients %}
+              <li>
+                <strong>{{ entry.client.name }}</strong>
+                <div class="is-size-7 has-text-grey">
+                  Última verificação:
+                  {% if entry.client.last_checked %}
+                    {{ entry.client.last_checked.strftime('%d/%m/%Y %H:%M') }}
+                  {% else %}
+                    nunca
+                  {% endif %}
+                </div>
+                <form
+                  action="{{ url_for('run_cycle_for_client', document=entry.client.document) }}"
+                  method="post"
+                  style="margin-top: 0.5rem;"
+                >
+                  <button class="button is-small is-primary is-light" type="submit" {% if not config_available %}disabled{% endif %}>
+                    Verificar agora
+                  </button>
+                </form>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="has-text-grey">Todos os clientes foram verificados nas últimas 24 horas.</p>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="card dashboard-card" style="margin-top: 1.5rem;">
+      <header class="card-header">
+        <p class="card-header-title">Guia rápido de operação</p>
+      </header>
+      <div class="card-content">
+        <p class="is-size-6">
+          • Atualize certificados e tokens nas ações de cada cliente.<br>
+          • Utilize o ciclo global diário para consolidar notificações.<br>
+          • Configure o <code>MONITOR_CONFIG</code> e o <code>MONITOR_DATABASE</code> em produção.
+        </p>
+        <p class="is-size-7 has-text-grey" style="margin-top: 0.75rem;">
+          A documentação completa está no arquivo README.md do projeto.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,227 @@
+"""Aplicação web para operar o monitoramento do eCAC."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from flask import (
+    Flask,
+    Response,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+
+from main import (
+    AlertDispatcher,
+    Client,
+    DatabaseManager,
+    EcacAPIClient,
+    EcacMonitor,
+    MonitorConfig,
+)
+
+
+def _load_config() -> MonitorConfig:
+    config_path = Path(os.environ.get("MONITOR_CONFIG", "monitor_config.json"))
+    if not config_path.exists():
+        raise FileNotFoundError(
+            "Arquivo de configuração do monitor não encontrado. "
+            "Defina MONITOR_CONFIG com o caminho correto."
+        )
+    return MonitorConfig.load(config_path)
+
+
+def _load_database() -> DatabaseManager:
+    db_path = Path(os.environ.get("MONITOR_DATABASE", "monitor.db"))
+    return DatabaseManager(db_path)
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY", "change-me")
+
+    db = _load_database()
+
+    def _build_monitor() -> EcacMonitor:
+        config = _load_config()
+        api_client = EcacAPIClient(config)
+        dispatcher = AlertDispatcher(config.webhook_url, config.verify_ssl, config.timeout)
+        return EcacMonitor(db, api_client, dispatcher, config.poll_interval, config.verify_ssl)
+
+    @app.context_processor
+    def inject_globals() -> Dict[str, Any]:
+        config_env = os.environ.get("MONITOR_CONFIG")
+        available = bool(config_env and Path(config_env).exists())
+        return {"config_available": available}
+
+    def _prepare_status(client: Client) -> Optional[Dict[str, Any]]:
+        if not client.last_status:
+            return None
+        try:
+            return json.loads(client.last_status)
+        except json.JSONDecodeError:
+            return {"raw": client.last_status}
+
+    @app.get("/")
+    def index() -> str:
+        clients = db.list_clients()
+        enriched = []
+        for client in clients:
+            status = _prepare_status(client)
+            enriched.append({"client": client, "status": status})
+        return render_template("index.html", clients=enriched)
+
+    @app.get("/clients/new")
+    def new_client() -> str:
+        return render_template("add_client.html")
+
+    @app.post("/clients")
+    def create_client() -> Response:
+        form = request.form
+        required = ["document", "name", "client_type", "certificate", "key"]
+        missing = [field for field in required if not form.get(field)]
+        if missing:
+            flash(f"Campos obrigatórios ausentes: {', '.join(missing)}", "error")
+            return redirect(url_for("new_client"))
+
+        try:
+            db.add_client(
+                document=form["document"].strip(),
+                name=form["name"].strip(),
+                client_type=form["client_type"],
+                certificate_path=Path(form["certificate"]).expanduser(),
+                key_path=Path(form["key"]).expanduser(),
+                certificate_password=form.get("certificate_password") or None,
+                procuracao_token=form.get("procuracao_token") or None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            flash(f"Erro ao cadastrar cliente: {exc}", "error")
+            return redirect(url_for("new_client"))
+
+        flash("Cliente cadastrado com sucesso", "success")
+        return redirect(url_for("index"))
+
+    @app.get("/clients/<document>")
+    def client_detail(document: str) -> str:
+        client = db.get_client(document)
+        if not client:
+            flash("Cliente não encontrado", "error")
+            return redirect(url_for("index"))
+        status = _prepare_status(client)
+        return render_template("client_detail.html", client=client, status=status)
+
+    @app.post("/run-cycle")
+    def run_cycle() -> Response:
+        try:
+            monitor = _build_monitor()
+            monitor.run_cycle()
+        except FileNotFoundError as exc:
+            flash(str(exc), "error")
+            return redirect(url_for("index"))
+        except Exception as exc:  # noqa: BLE001
+            flash(f"Erro ao executar ciclo: {exc}", "error")
+            return redirect(url_for("index"))
+
+        flash("Ciclo executado com sucesso", "success")
+        return redirect(url_for("index"))
+
+    @app.post("/clients/<document>/run")
+    def run_cycle_for_client(document: str) -> Response:
+        try:
+            monitor = _build_monitor()
+            monitor.run_for_client(document)
+        except ValueError as exc:
+            flash(str(exc), "error")
+            return redirect(url_for("index"))
+        except FileNotFoundError as exc:
+            flash(str(exc), "error")
+            return redirect(url_for("client_detail", document=document))
+        except Exception as exc:  # noqa: BLE001
+            flash(f"Erro ao executar ciclo: {exc}", "error")
+            return redirect(url_for("client_detail", document=document))
+        flash("Ciclo executado com sucesso", "success")
+        return redirect(url_for("client_detail", document=document))
+
+    @app.get("/clients/<document>/events")
+    def client_events(document: str) -> str:
+        client = db.get_client(document)
+        if not client:
+            flash("Cliente não encontrado", "error")
+            return redirect(url_for("index"))
+        try:
+            limit = max(1, min(500, int(request.args.get("limit", 50))))
+            offset = max(0, int(request.args.get("offset", 0)))
+        except ValueError:
+            flash("Parâmetros de paginação inválidos", "error")
+            return redirect(url_for("client_events", document=document))
+        events = db.list_events(document, limit=limit, offset=offset)
+        return render_template(
+            "client_events.html",
+            client=client,
+            events=events,
+            limit=limit,
+            offset=offset,
+        )
+
+    @app.get("/clients/<document>/edit")
+    def edit_client(document: str) -> str:
+        client = db.get_client(document)
+        if not client:
+            flash("Cliente não encontrado", "error")
+            return redirect(url_for("index"))
+        return render_template("edit_client.html", client=client)
+
+    @app.post("/clients/<document>")
+    def update_client(document: str) -> Response:
+        client = db.get_client(document)
+        if not client:
+            flash("Cliente não encontrado", "error")
+            return redirect(url_for("index"))
+        form = request.form
+        fields: Dict[str, Any] = {}
+        if form.get("name"):
+            fields["name"] = form["name"].strip()
+        if form.get("client_type"):
+            fields["client_type"] = form["client_type"]
+        if form.get("certificate"):
+            fields["certificate_path"] = Path(form["certificate"]).expanduser()
+        if form.get("key"):
+            fields["key_path"] = Path(form["key"]).expanduser()
+        if form.get("certificate_password") is not None:
+            fields["certificate_password"] = form.get("certificate_password") or None
+        if form.get("procuracao_token") is not None:
+            fields["procuracao_token"] = form.get("procuracao_token") or None
+        if not fields:
+            flash("Nenhuma alteração informada", "warning")
+            return redirect(url_for("edit_client", document=document))
+        try:
+            db.update_client(document, **fields)
+        except Exception as exc:  # noqa: BLE001
+            flash(f"Erro ao atualizar cliente: {exc}", "error")
+            return redirect(url_for("edit_client", document=document))
+        flash("Cliente atualizado com sucesso", "success")
+        return redirect(url_for("client_detail", document=document))
+
+    @app.post("/clients/<document>/delete")
+    def delete_client(document: str) -> Response:
+        try:
+            db.delete_client(document)
+        except ValueError as exc:
+            flash(str(exc), "error")
+            return redirect(url_for("index"))
+        flash("Cliente removido", "success")
+        return redirect(url_for("index"))
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8000)), debug=False)

--- a/webapp.py
+++ b/webapp.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -19,6 +20,7 @@ from flask import (
 from main import (
     AlertDispatcher,
     Client,
+    DashboardMetrics,
     DatabaseManager,
     EcacAPIClient,
     EcacMonitor,
@@ -67,14 +69,90 @@ def create_app() -> Flask:
         except json.JSONDecodeError:
             return {"raw": client.last_status}
 
+    def _format_event(event) -> Dict[str, Any]:
+        payload = event.payload
+        summary = None
+        description = None
+        category = None
+        reference = None
+        if isinstance(payload, dict):
+            for key in ("title", "titulo", "subject", "assunto"):
+                if payload.get(key):
+                    summary = str(payload[key])
+                    break
+            description = (
+                payload.get("description")
+                or payload.get("mensagem")
+                or payload.get("message")
+            )
+            category = payload.get("category") or payload.get("categoria")
+            reference = (
+                payload.get("reference")
+                or payload.get("protocolo")
+                or payload.get("id")
+            )
+        if summary is None:
+            if isinstance(payload, (str, int, float)):
+                summary = str(payload)
+            else:
+                summary = json.dumps(payload, ensure_ascii=False)
+        return {
+            "id": event.id,
+            "client_document": event.client_document,
+            "client_name": getattr(event, "client_name", None),
+            "received_at": event.received_at,
+            "summary": summary,
+            "description": description,
+            "category": category,
+            "reference": reference,
+            "payload": payload,
+        }
+
     @app.get("/")
     def index() -> str:
         clients = db.list_clients()
+        metrics: DashboardMetrics = db.get_dashboard_metrics()
         enriched = []
         for client in clients:
             status = _prepare_status(client)
-            enriched.append({"client": client, "status": status})
-        return render_template("index.html", clients=enriched)
+            notifications = 0
+            obligations = 0
+            if isinstance(status, dict):
+                notifications_field = status.get("notifications") or status.get("avisos")
+                if isinstance(notifications_field, list):
+                    notifications = len(notifications_field)
+                obligations_field = (
+                    status.get("obligations")
+                    or status.get("obrigacoes")
+                    or status.get("obrigações")
+                )
+                if isinstance(obligations_field, list):
+                    obligations = len(obligations_field)
+            enriched.append(
+                {
+                    "client": client,
+                    "status": status,
+                    "notifications": notifications,
+                    "obligations": obligations,
+                }
+            )
+
+        stale_threshold = datetime.utcnow() - timedelta(hours=24)
+        stale_clients = [
+            entry
+            for entry in enriched
+            if not entry["client"].last_checked
+            or entry["client"].last_checked < stale_threshold
+        ]
+        recent_events = [_format_event(event) for event in db.list_events(limit=6)]
+
+        return render_template(
+            "index.html",
+            clients=enriched,
+            metrics=metrics,
+            stale_clients=stale_clients,
+            recent_events=recent_events,
+        )
 
     @app.get("/clients/new")
     def new_client() -> str:
@@ -113,7 +191,35 @@ def create_app() -> Flask:
             flash("Cliente não encontrado", "error")
             return redirect(url_for("index"))
         status = _prepare_status(client)
-        return render_template("client_detail.html", client=client, status=status)
+        notifications = []
+        obligations = []
+        metadata: Dict[str, Any] = {}
+        if isinstance(status, dict):
+            raw_notifications = status.get("notifications") or status.get("avisos")
+            if isinstance(raw_notifications, list):
+                notifications = raw_notifications
+            raw_obligations = (
+                status.get("obligations")
+                or status.get("obrigacoes")
+                or status.get("obrigações")
+            )
+            if isinstance(raw_obligations, list):
+                obligations = raw_obligations
+            meta_candidate = status.get("metadata") or status.get("metadados")
+            if isinstance(meta_candidate, dict):
+                metadata = meta_candidate
+        recent_events = [
+            _format_event(event) for event in db.list_events(document, limit=5)
+        ]
+        return render_template(
+            "client_detail.html",
+            client=client,
+            status=status,
+            notifications=notifications,
+            obligations=obligations,
+            metadata=metadata,
+            recent_events=recent_events,
+        )
 
     @app.post("/run-cycle")
     def run_cycle() -> Response:
@@ -160,12 +266,15 @@ def create_app() -> Flask:
             flash("Parâmetros de paginação inválidos", "error")
             return redirect(url_for("client_events", document=document))
         events = db.list_events(document, limit=limit, offset=offset)
+        formatted_events = [_format_event(event) for event in events]
         return render_template(
             "client_events.html",
             client=client,
-            events=events,
+            events=formatted_events,
             limit=limit,
             offset=offset,
+            next_offset=offset + limit if len(events) == limit else None,
+            prev_offset=offset - limit if offset - limit >= 0 else None,
         )
 
     @app.get("/clients/<document>/edit")


### PR DESCRIPTION
## Summary
- adiciona utilitários ao banco de dados e ao monitor para recuperar, atualizar e remover clientes, listar eventos e executar ciclos individuais
- estende a CLI com comandos de atualização, exclusão, consulta de status, histórico de eventos e suporte a `--client` ao rodar o monitor
- amplia o painel Flask com edição e remoção de clientes, visualização do histórico de eventos e ações rápidas, atualizando os templates e a documentação

## Testing
- python -m compileall main.py webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68e2c607c4a48329944f8f2c74d94ed8