### PR TITLE
Enable per-client procuracao authentication paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,172 @@
+# Monitoramento do eCAC
+
+Este repositório contém uma ferramenta CLI em Python para monitorar periodicamente o eCAC para escritórios de contabilidade. Ela autentica usando o certificado digital de cada contribuinte (empresa ou pessoa física) ou, opcionalmente, apenas a procuração eletrônica do contador, consulta uma API proprietária e registra novos eventos em um banco SQLite, disparando alertas via webhook.
+
+## Requisitos
+
+- Python 3.9 ou superior
+- Bibliotecas [`requests`](https://pypi.org/project/requests/) e [`Flask`](https://flask.palletsprojects.com/)
+- Certificados digitais (`.pem`) dos clientes que usarão o modo por certificado e procuração eletrônica ativa para o contador
+- API própria do escritório capaz de autenticar e consultar notificações/obrigações do eCAC
+
+Instale a dependência:
+
+```bash
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+## Configuração da API
+
+1. Copie o arquivo de exemplo `monitor_config.example.json` para `monitor_config.json` e edite os valores:
+   - `api_base_url`: URL base da API proprietária (sem barra no final).
+   - `contador_document`: CPF/CNPJ do contador com procuração.
+   - `procuracao_token`: token padrão usado na autorização.
+   - Opcional: `poll_interval`, `verify_ssl`, `timeout`, `webhook_url`.
+2. Garanta que os certificados `.pem` dos clientes que utilizarem o modo por certificado estejam acessíveis no servidor onde o monitor rodará. Para clientes configurados apenas com procuração, assegure que o token padrão ou individual esteja válido.
+
+## Banco de dados
+
+O monitor cria automaticamente o arquivo SQLite definido por `--database` (padrão `monitor.db`) com as tabelas `clients` e `events`. Faça backup periódico desse arquivo se precisar de histórico.
+
+## Cadastro de clientes
+
+Utilize o comando `add-client` para registrar cada contribuinte, escolhendo o modo de autenticação mais adequado ao cenário.
+
+### Exemplo com certificado do contribuinte
+
+```bash
+python main.py add-client \
+  --database monitor.db \
+  12345678000190 "Empresa Exemplo Ltda" PJ \
+  /caminho/certificados/empresa.pem \
+  /caminho/certificados/empresa-key.pem \
+  --certificate-password "senhaOpcional" \
+  --procuracao-token "tokenOpcional"
+```
+
+### Exemplo usando apenas a procuração do contador
+
+```bash
+python main.py add-client \
+  --database monitor.db \
+  98765432100 "Contribuinte via Procuração" PF \
+  --auth-mode procuracao \
+  --procuracao-token "tokenEspecificoOpcional"
+```
+
+No modo `procuracao`, os campos de certificado e chave são opcionais e podem ser omitidos. Se nenhum token específico for informado, o sistema utilizará o valor padrão configurado em `monitor_config.json`.
+
+Para listar os clientes cadastrados:
+
+```bash
+python main.py list-clients --database monitor.db
+```
+
+### Atualização, remoção e status de clientes
+
+- Atualize informações (nome, tipo, caminhos de arquivos ou credenciais específicas):
+
+  ```bash
+  python main.py update-client \
+    --database monitor.db \
+    12345678000190 \
+    --name "Empresa Nova" \
+    --certificate /novo/caminho/cert.pem \
+    --key /novo/caminho/key.pem
+  ```
+
+  Para alternar o modo de autenticação para o uso exclusivo da procuração, execute:
+
+  ```bash
+  python main.py update-client \
+    --database monitor.db \
+    12345678000190 \
+    --auth-mode procuracao
+  ```
+
+- Remova um cliente (os eventos associados também são excluídos):
+
+  ```bash
+  python main.py delete-client --database monitor.db 12345678000190
+  ```
+
+- Consulte o último status consolidado retornado pela API:
+
+  ```bash
+  python main.py show-status --database monitor.db 12345678000190
+  ```
+
+- Liste eventos registrados, com suporte a filtros e paginação simples:
+
+  ```bash
+  python main.py list-events --database monitor.db --document 12345678000190 --limit 20
+  ```
+
+## Execução do monitoramento
+
+### Execução contínua
+
+Para rodar continuamente (modo daemon simples), use:
+
+```bash
+python main.py run --database monitor.db --config monitor_config.json
+```
+
+O processo fica em loop consultando a API a cada `poll_interval` segundos, atualizando o banco e enviando alertas para o webhook (quando configurado).
+
+### Execução de ciclo único
+
+Se quiser executar apenas um ciclo (por exemplo, em uma pipeline agendada ou cron job), adicione `--once`:
+
+```bash
+python main.py run --database monitor.db --config monitor_config.json --once
+```
+
+Para executar o ciclo apenas para um cliente específico (útil em fluxos manuais ou integrações), informe `--client`:
+
+```bash
+python main.py run --database monitor.db --config monitor_config.json --client 12345678000190
+```
+
+## Interface web
+
+Além da CLI, o repositório inclui um painel web completo (`webapp.py`) para cadastrar clientes, visualizar métricas consolidadas e disparar ciclos manuais do monitor.
+
+1. Configure as variáveis de ambiente:
+   ```bash
+   export MONITOR_DATABASE=monitor.db
+   export MONITOR_CONFIG=/caminho/para/monitor_config.json
+   export FLASK_SECRET_KEY="uma-string-aleatoria"
+   ```
+2. Inicie o servidor:
+   ```bash
+   python webapp.py
+   ```
+3. Acesse `http://localhost:8000` para visualizar clientes, cadastrar novos, editar registros, remover cadastros, examinar o
+   histórico de eventos e executar ciclos sob demanda (globais ou por cliente).
+
+### Recursos disponíveis no painel
+
+- **Dashboard operacional** com contadores de clientes, eventos, últimos ciclos e destaque para clientes que precisam de nova verificação.
+- **Linha do tempo dos eventos** com visualização amigável, filtros de paginação, destaque de categorias/referências e exibição do payload bruto por evento.
+- **Páginas de detalhe** para cada cliente exibindo notificações mais recentes, obrigações, metadados retornados pela API e ações rápidas (rodar ciclo, editar, remover).
+- **Formulários estruturados** para cadastro e edição, incluindo seleção do modo de autenticação e dicas operacionais ao lado dos campos obrigatórios.
+- **Estilo responsivo** baseado em Bulma com personalizações próprias (`static/css/app.css`) para cards, timeline e blocos de informação.
+
+O painel reutiliza o mesmo banco SQLite e respeita as configurações do arquivo JSON. Certifique-se de que o processo tenha acesso
+aos certificados dos clientes que utilizarem esse modo e aos tokens de procuração necessários.
+
+## Logs e observabilidade
+
+Os logs são enviados para `stdout` com nível `INFO` por padrão. Para aumentar a verbosidade, ajuste a variável de ambiente `PYTHONLOGLEVEL` ou modifique `logging.basicConfig` em `main.py`.
+
+## Deploy sugerido
+
+- Configure um serviço do sistema (ex.: `systemd`) para iniciar o comando contínuo após o boot.
+- Armazene os certificados (quando aplicável) em diretório protegido e mantenha os tokens de procuração em local seguro, com permissões restritas ao usuário que executa o monitor.
+- Utilize `venv` dedicado para isolar as dependências Python.
+
+## Suporte
+
+Em caso de dúvidas, entre em contato com o time responsável pela API proprietária ou adapte o código para atender às particularidades do seu escritório.

--- a/README.md
+++ b/README.md
@@ -16,14 +16,64 @@ python -m pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-## Configuração da API
+## Configuração da API proprietária incluída
 
-1. Copie o arquivo de exemplo `monitor_config.example.json` para `monitor_config.json` e edite os valores:
-   - `api_base_url`: URL base da API proprietária (sem barra no final).
-   - `contador_document`: CPF/CNPJ do contador com procuração.
-   - `procuracao_token`: token padrão usado na autorização.
-   - Opcional: `poll_interval`, `verify_ssl`, `timeout`, `webhook_url`.
-2. Garanta que os certificados `.pem` dos clientes que utilizarem o modo por certificado estejam acessíveis no servidor onde o monitor rodará. Para clientes configurados apenas com procuração, assegure que o token padrão ou individual esteja válido.
+O repositório agora acompanha uma API real (`api_server.py`) que atende aos mesmos contratos esperados pelo monitor. Ela armazena clientes, notificações e obrigações em SQLite e valida o acesso por certificado ou pela procuração do contador.
+
+1. Copie `api_config.example.json` para `api_config.json` e defina seus valores reais:
+   - `contador_document`: informe o CPF/CNPJ do contador que assina as procurações (por exemplo, `97121215187`).
+   - `default_procuracao_token`: token padrão emitido no eCAC para o contador.
+   - `access_token_ttl`: tempo de vida (em minutos) dos tokens de acesso emitidos pela API.
+   - `admin_token`: segredo usado para autenticar as rotas administrativas (troque por um valor robusto).
+2. Inicie a API:
+
+   ```bash
+   export API_CONFIG=api_config.json
+   export API_DATABASE=api_data.db
+   python api_server.py
+   ```
+
+3. Cadastre cada cliente autorizado (PJ ou PF). Exemplo usando apenas a procuração do contador:
+
+   ```bash
+   curl -X POST http://localhost:5000/admin/clients \
+     -H "Content-Type: application/json" \
+     -H "X-Admin-Token: SEU_TOKEN_ADMIN" \
+     -d '{
+       "document": "12345678000190",
+       "name": "Empresa Exemplo Ltda",
+       "client_type": "PJ",
+       "procuracao_token": "token-especifico-opcional"
+     }'
+   ```
+
+4. Alimente a API com notificações e obrigações sempre que houver novos dados do eCAC (por integração automática ou operação manual). Exemplos:
+
+   ```bash
+   curl -X POST http://localhost:5000/admin/clients/12345678000190/notifications \
+     -H "Content-Type: application/json" \
+     -H "X-Admin-Token: SEU_TOKEN_ADMIN" \
+     -d '{
+       "notification": {
+         "title": "Mensagem do eCAC",
+         "category": "Avisos",
+         "protocol": "2024-0001"
+       }
+     }'
+
+   curl -X POST http://localhost:5000/admin/clients/12345678000190/obligations \
+     -H "Content-Type: application/json" \
+     -H "X-Admin-Token: SEU_TOKEN_ADMIN" \
+     -d '{
+       "obligations": [
+         {"description": "Entrega DCTF", "due_date": "2024-06-30", "status": "pending"}
+       ]
+     }'
+   ```
+
+5. Atualize `monitor_config.json` (copiado de `monitor_config.example.json`) apontando `api_base_url` para `http://localhost:5000`, definindo o mesmo `contador_document` e o token padrão desejado. Opcionalmente ajuste `poll_interval`, `verify_ssl`, `timeout` e `webhook_url`.
+
+6. Garanta que os certificados `.pem` dos clientes que utilizarem o modo por certificado estejam acessíveis no servidor. Para cadastros que operarão somente com a procuração do contador, basta configurar o token padrão ou individual conforme os passos anteriores.
 
 ## Banco de dados
 
@@ -133,7 +183,7 @@ python main.py run --database monitor.db --config monitor_config.json --client 1
 
 Além da CLI, o repositório inclui um painel web completo (`webapp.py`) para cadastrar clientes, visualizar métricas consolidadas e disparar ciclos manuais do monitor.
 
-1. Configure as variáveis de ambiente:
+1. Configure as variáveis de ambiente (use o mesmo banco e configuração apontados pelo monitor):
    ```bash
    export MONITOR_DATABASE=monitor.db
    export MONITOR_CONFIG=/caminho/para/monitor_config.json
@@ -144,7 +194,8 @@ Além da CLI, o repositório inclui um painel web completo (`webapp.py`) para ca
    python webapp.py
    ```
 3. Acesse `http://localhost:8000` para visualizar clientes, cadastrar novos, editar registros, remover cadastros, examinar o
-   histórico de eventos e executar ciclos sob demanda (globais ou por cliente).
+   histórico de eventos e executar ciclos sob demanda (globais ou por cliente). Caso a página inicial informe que a configuração
+   não foi encontrada, verifique se `MONITOR_CONFIG` aponta para o arquivo correto e que ele está acessível.
 
 ### Recursos disponíveis no painel
 

--- a/api_config.example.json
+++ b/api_config.example.json
@@ -1,0 +1,6 @@
+{
+  "contador_document": "97121215187",
+  "default_procuracao_token": "token-padrao-procuracao",
+  "access_token_ttl": 120,
+  "admin_token": "troque-este-token-admin"
+}

--- a/api_server.py
+++ b/api_server.py
@@ -1,0 +1,370 @@
+"""API proprietária para integrar o monitoramento do eCAC."""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from flask import Flask, abort, jsonify, request
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+
+@dataclass
+class APIConfig:
+    """Configurações principais da API."""
+
+    contador_document: str
+    default_procuracao_token: str
+    access_token_ttl: int = 60  # minutos
+    admin_token: Optional[str] = None
+
+    @classmethod
+    def load(cls, path: Path) -> "APIConfig":
+        with path.open("r", encoding="utf-8") as fp:
+            data = json.load(fp)
+        missing = [field for field in ("contador_document", "default_procuracao_token") if field not in data]
+        if missing:
+            raise ValueError(
+                "Configuração inválida da API, campos obrigatórios ausentes: " + ", ".join(missing)
+            )
+        return cls(
+            contador_document=data["contador_document"],
+            default_procuracao_token=data["default_procuracao_token"],
+            access_token_ttl=int(data.get("access_token_ttl", 60)),
+            admin_token=data.get("admin_token"),
+        )
+
+
+class APIDatabase:
+    """Gerencia o armazenamento de clientes, notificações e tokens."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS clients (
+                    document TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    client_type TEXT NOT NULL CHECK (client_type IN ('PJ', 'PF')),
+                    procuracao_token TEXT,
+                    certificate_identifier TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS notifications (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    client_document TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (client_document) REFERENCES clients(document) ON DELETE CASCADE
+                );
+
+                CREATE TABLE IF NOT EXISTS obligations (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    client_document TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    status TEXT,
+                    due_date TEXT,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (client_document) REFERENCES clients(document) ON DELETE CASCADE
+                );
+
+                CREATE TABLE IF NOT EXISTS access_tokens (
+                    token TEXT PRIMARY KEY,
+                    client_document TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (client_document) REFERENCES clients(document) ON DELETE CASCADE
+                );
+                """
+            )
+
+    # ------------------------------------------------------------------
+    # Clientes
+    # ------------------------------------------------------------------
+    def upsert_client(
+        self,
+        document: str,
+        name: str,
+        client_type: str,
+        procuracao_token: Optional[str] = None,
+        certificate_identifier: Optional[str] = None,
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO clients (document, name, client_type, procuracao_token, certificate_identifier)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(document) DO UPDATE SET
+                    name=excluded.name,
+                    client_type=excluded.client_type,
+                    procuracao_token=excluded.procuracao_token,
+                    certificate_identifier=excluded.certificate_identifier
+                """,
+                (document, name, client_type, procuracao_token, certificate_identifier),
+            )
+
+    def get_client(self, document: str) -> Optional[sqlite3.Row]:
+        with self._connect() as conn:
+            return conn.execute("SELECT * FROM clients WHERE document = ?", (document,)).fetchone()
+
+    # ------------------------------------------------------------------
+    # Tokens de acesso
+    # ------------------------------------------------------------------
+    def create_access_token(self, document: str, ttl_minutes: int) -> str:
+        token = secrets.token_urlsafe(32)
+        expires_at = datetime.utcnow() + timedelta(minutes=ttl_minutes)
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO access_tokens (token, client_document, expires_at, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    token,
+                    document,
+                    expires_at.strftime(ISO_FORMAT),
+                    datetime.utcnow().strftime(ISO_FORMAT),
+                ),
+            )
+        return token
+
+    def validate_token(self, token: str) -> Optional[str]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT client_document, expires_at FROM access_tokens WHERE token = ?",
+                (token,),
+            ).fetchone()
+        if not row:
+            return None
+        expires_at = datetime.strptime(row["expires_at"], ISO_FORMAT)
+        if expires_at < datetime.utcnow():
+            self.delete_token(token)
+            return None
+        return row["client_document"]
+
+    def delete_token(self, token: str) -> None:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM access_tokens WHERE token = ?", (token,))
+
+    # ------------------------------------------------------------------
+    # Notificações e obrigações
+    # ------------------------------------------------------------------
+    def list_notifications(self, document: str) -> list[Dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT payload, created_at FROM notifications WHERE client_document = ? ORDER BY id DESC",
+                (document,),
+            ).fetchall()
+        notifications = []
+        for row in rows:
+            payload = json.loads(row["payload"])
+            payload.setdefault("created_at", row["created_at"])
+            notifications.append(payload)
+        return notifications
+
+    def append_notification(self, document: str, payload: Dict[str, Any]) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO notifications (client_document, payload, created_at)
+                VALUES (?, ?, ?)
+                """,
+                (document, json.dumps(payload, ensure_ascii=False), datetime.utcnow().strftime(ISO_FORMAT)),
+            )
+
+    def list_obligations(self, document: str) -> list[Dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT payload, status, due_date, created_at
+                FROM obligations
+                WHERE client_document = ?
+                ORDER BY id DESC
+                """,
+                (document,),
+            ).fetchall()
+        obligations: list[Dict[str, Any]] = []
+        for row in rows:
+            payload = json.loads(row["payload"])
+            if row["status"]:
+                payload.setdefault("status", row["status"])
+            if row["due_date"]:
+                payload.setdefault("due_date", row["due_date"])
+            payload.setdefault("updated_at", row["created_at"])
+            obligations.append(payload)
+        return obligations
+
+    def replace_obligations(self, document: str, obligations: list[Dict[str, Any]]) -> None:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM obligations WHERE client_document = ?", (document,))
+            now = datetime.utcnow().strftime(ISO_FORMAT)
+            for item in obligations:
+                conn.execute(
+                    """
+                    INSERT INTO obligations (client_document, payload, status, due_date, created_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        document,
+                        json.dumps(item, ensure_ascii=False),
+                        item.get("status"),
+                        item.get("due_date"),
+                        now,
+                    ),
+                )
+
+
+def create_app(config: APIConfig, database: APIDatabase) -> Flask:
+    app = Flask(__name__)
+
+    def require_admin() -> None:
+        if not config.admin_token:
+            return
+        provided = request.headers.get("X-Admin-Token")
+        if provided != config.admin_token:
+            abort(401, "Admin token inválido")
+
+    def require_access_token() -> str:
+        header = request.headers.get("Authorization", "")
+        if not header.startswith("Bearer "):
+            abort(401, "Token ausente")
+        token = header.split(" ", 1)[1]
+        document = database.validate_token(token)
+        if not document:
+            abort(401, "Token inválido ou expirado")
+        return document
+
+    @app.post("/auth/procuracao")
+    def auth_procuracao() -> Any:
+        payload = request.get_json(force=True)
+        for field in ("document", "client_type", "contador_document"):
+            if field not in payload:
+                abort(400, f"Campo obrigatório ausente: {field}")
+        if payload["contador_document"] != config.contador_document:
+            abort(401, "Contador não autorizado")
+        client = database.get_client(payload["document"])
+        if not client:
+            abort(404, "Cliente não cadastrado")
+        if client["client_type"] != payload["client_type"]:
+            abort(400, "Tipo de cliente divergente")
+        provided_token = payload.get("procuracao_token") or config.default_procuracao_token
+        valid_token = client["procuracao_token"] or config.default_procuracao_token
+        if provided_token != valid_token:
+            abort(401, "Token de procuração inválido")
+        token = database.create_access_token(client["document"], config.access_token_ttl)
+        return jsonify({"access_token": token, "expires_in": config.access_token_ttl * 60})
+
+    @app.post("/auth/certificate")
+    def auth_certificate() -> Any:
+        payload = request.get_json(force=True)
+        for field in ("document", "client_type"):
+            if field not in payload:
+                abort(400, f"Campo obrigatório ausente: {field}")
+        client = database.get_client(payload["document"])
+        if not client:
+            abort(404, "Cliente não cadastrado")
+        if client["client_type"] != payload["client_type"]:
+            abort(400, "Tipo de cliente divergente")
+        identifier = payload.get("certificate_identifier")
+        stored_identifier = client["certificate_identifier"]
+        if stored_identifier and identifier != stored_identifier:
+            abort(401, "Certificado não autorizado")
+        token = database.create_access_token(client["document"], config.access_token_ttl)
+        return jsonify({"access_token": token, "expires_in": config.access_token_ttl * 60})
+
+    @app.get("/ecac/<document>/notifications")
+    def get_notifications(document: str) -> Any:
+        token_document = require_access_token()
+        if token_document != document:
+            abort(403, "Token não corresponde ao cliente consultado")
+        data = database.list_notifications(document)
+        return jsonify({"notifications": data})
+
+    @app.get("/ecac/<document>/obligations")
+    def get_obligations(document: str) -> Any:
+        token_document = require_access_token()
+        if token_document != document:
+            abort(403, "Token não corresponde ao cliente consultado")
+        data = database.list_obligations(document)
+        return jsonify({"obligations": data})
+
+    # ------------------------------------------------------------------
+    # Endpoints administrativos para alimentar a API
+    # ------------------------------------------------------------------
+    @app.post("/admin/clients")
+    def create_or_update_client() -> Any:
+        require_admin()
+        payload = request.get_json(force=True)
+        for field in ("document", "name", "client_type"):
+            if field not in payload:
+                abort(400, f"Campo obrigatório ausente: {field}")
+        database.upsert_client(
+            document=payload["document"],
+            name=payload["name"],
+            client_type=payload["client_type"],
+            procuracao_token=payload.get("procuracao_token"),
+            certificate_identifier=payload.get("certificate_identifier"),
+        )
+        return jsonify({"status": "ok"})
+
+    @app.post("/admin/clients/<document>/notifications")
+    def append_client_notification(document: str) -> Any:
+        require_admin()
+        payload = request.get_json(force=True)
+        if "notification" in payload:
+            entry = payload["notification"]
+        else:
+            entry = payload
+        if not isinstance(entry, dict):
+            abort(400, "Notification inválida")
+        if not database.get_client(document):
+            abort(404, "Cliente não encontrado")
+        database.append_notification(document, entry)
+        return jsonify({"status": "ok"})
+
+    @app.post("/admin/clients/<document>/obligations")
+    def replace_client_obligations(document: str) -> Any:
+        require_admin()
+        payload = request.get_json(force=True)
+        obligations = payload.get("obligations")
+        if not isinstance(obligations, list):
+            abort(400, "Campo 'obligations' deve ser uma lista")
+        if not database.get_client(document):
+            abort(404, "Cliente não encontrado")
+        database.replace_obligations(document, obligations)
+        return jsonify({"status": "ok"})
+
+    return app
+
+
+def load_app() -> Flask:
+    config_path = Path(os.environ.get("API_CONFIG", "api_config.json"))
+    if not config_path.exists():
+        raise FileNotFoundError(
+            "Arquivo de configuração da API não encontrado. Defina API_CONFIG ou crie api_config.json."
+        )
+    config = APIConfig.load(config_path)
+    db_path = Path(os.environ.get("API_DATABASE", "api_data.db"))
+    database = APIDatabase(db_path)
+    return create_app(config, database)
+app = load_app()
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("API_PORT", 5000)), debug=False)

--- a/main.py
+++ b/main.py
@@ -1,1 +1,936 @@
+"""Ferramenta de monitoramento contínuo do eCAC para escritórios de contabilidade.
 
+Este módulo fornece uma linha de comando para registrar clientes (empresas ou pessoas
+físicas) e acompanhar notificações do eCAC por meio de uma API própria do escritório.
+As requisições podem ser autenticadas com o certificado digital do contribuinte ou
+apenas com a procuração eletrônica do contador, permitindo flexibilidade para cada
+cadastro.
+
+O código foi escrito para ser direto e pronto para uso em produção, sem mocks
+ou simulações. Ajuste apenas as configurações de acesso (endereços da API,
+caminhos dos certificados, tokens de procuração e URLs de alerta) antes de
+colocá-lo em operação.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+try:
+    import requests
+except ImportError as exc:  # pragma: no cover - dependência obrigatória em produção
+    raise SystemExit(
+        "Dependência 'requests' não encontrada. Instale-a com 'pip install requests'."
+    ) from exc
+
+LOGGER = logging.getLogger("ecac_monitor")
+
+AUTH_MODES = {"certificate", "procuracao"}
+
+
+@dataclass
+class MonitorConfig:
+    """Representa a configuração principal do monitor."""
+
+    api_base_url: str
+    contador_document: str
+    procuracao_token: str
+    poll_interval: int = 900
+    verify_ssl: bool = True
+    timeout: int = 60
+    webhook_url: Optional[str] = None
+
+    @classmethod
+    def load(cls, path: Path) -> "MonitorConfig":
+        with path.open("r", encoding="utf-8") as fp:
+            data = json.load(fp)
+        required = {"api_base_url", "contador_document", "procuracao_token"}
+        missing = [field for field in required if field not in data]
+        if missing:
+            raise ValueError(
+                f"Configuração inválida: campos obrigatórios ausentes {', '.join(missing)}"
+            )
+        return cls(
+            api_base_url=data["api_base_url"].rstrip("/"),
+            contador_document=data["contador_document"],
+            procuracao_token=data["procuracao_token"],
+            poll_interval=int(data.get("poll_interval", 900)),
+            verify_ssl=bool(data.get("verify_ssl", True)),
+            timeout=int(data.get("timeout", 60)),
+            webhook_url=data.get("webhook_url"),
+        )
+
+
+@dataclass
+class Client:
+    document: str
+    name: str
+    client_type: str  # PJ ou PF
+    auth_mode: str  # certificate ou procuracao
+    certificate_path: Optional[Path]
+    key_path: Optional[Path]
+    certificate_password: Optional[str]
+    procuracao_token: Optional[str]
+    last_status: Optional[str]
+    last_checked: Optional[datetime]
+
+
+@dataclass
+class EventRecord:
+    id: int
+    client_document: str
+    payload: Dict[str, Any]
+    received_at: datetime
+    client_name: Optional[str] = None
+
+
+@dataclass
+class DashboardMetrics:
+    """Representa indicadores consolidados para o painel web."""
+
+    total_clients: int
+    pj_clients: int
+    pf_clients: int
+    total_events: int
+    clients_with_alerts: int
+    last_check: Optional[datetime]
+    last_event: Optional[datetime]
+
+
+class DatabaseManager:
+    """Responsável por persistir dados locais do monitor."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS clients (
+                    document TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    client_type TEXT NOT NULL CHECK (client_type IN ('PJ', 'PF')),
+                    auth_mode TEXT NOT NULL DEFAULT 'certificate'
+                        CHECK (auth_mode IN ('certificate', 'procuracao')),
+                    certificate_path TEXT,
+                    key_path TEXT,
+                    certificate_password TEXT,
+                    procuracao_token TEXT,
+                    last_status TEXT,
+                    last_checked TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    client_document TEXT NOT NULL,
+                    event_hash TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    received_at TEXT NOT NULL,
+                    FOREIGN KEY (client_document) REFERENCES clients(document)
+                );
+
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_events_document_hash
+                    ON events(client_document, event_hash);
+                """
+            )
+            self._migrate_clients_table(conn)
+
+    def _migrate_clients_table(self, conn: sqlite3.Connection) -> None:
+        info = conn.execute("PRAGMA table_info(clients)").fetchall()
+        if not info:
+            return
+
+        columns = {row[1]: row for row in info}
+        auth_present = "auth_mode" in columns
+        certificate_nullable = not columns["certificate_path"][3]
+        key_nullable = not columns["key_path"][3]
+
+        if auth_present and certificate_nullable and key_nullable:
+            return
+
+        auth_select = "auth_mode" if auth_present else "'certificate'"
+        conn.executescript(
+            f"""
+            CREATE TABLE clients_new (
+                document TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                client_type TEXT NOT NULL CHECK (client_type IN ('PJ', 'PF')),
+                auth_mode TEXT NOT NULL DEFAULT 'certificate'
+                    CHECK (auth_mode IN ('certificate', 'procuracao')),
+                certificate_path TEXT,
+                key_path TEXT,
+                certificate_password TEXT,
+                procuracao_token TEXT,
+                last_status TEXT,
+                last_checked TEXT
+            );
+
+            INSERT INTO clients_new (
+                document, name, client_type, auth_mode,
+                certificate_path, key_path, certificate_password,
+                procuracao_token, last_status, last_checked
+            )
+            SELECT
+                document,
+                name,
+                client_type,
+                COALESCE({auth_select}, 'certificate') AS auth_mode,
+                certificate_path,
+                key_path,
+                certificate_password,
+                procuracao_token,
+                last_status,
+                last_checked
+            FROM clients;
+
+            DROP TABLE clients;
+            ALTER TABLE clients_new RENAME TO clients;
+
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_events_document_hash
+                ON events(client_document, event_hash);
+            """
+        )
+
+    # Métodos públicos -------------------------------------------------
+    def add_client(
+        self,
+        document: str,
+        name: str,
+        client_type: str,
+        auth_mode: str,
+        certificate_path: Optional[Path],
+        key_path: Optional[Path],
+        certificate_password: Optional[str],
+        procuracao_token: Optional[str],
+    ) -> None:
+        if auth_mode not in AUTH_MODES:
+            raise ValueError(f"Modo de autenticação inválido: {auth_mode}")
+        if auth_mode == "certificate" and (not certificate_path or not key_path):
+            raise ValueError(
+                "Certificado e chave são obrigatórios quando o modo é 'certificate'"
+            )
+        if auth_mode == "procuracao":
+            certificate_path = None
+            key_path = None
+            certificate_password = None
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO clients (
+                    document, name, client_type, auth_mode,
+                    certificate_path, key_path,
+                    certificate_password, procuracao_token
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    document,
+                    name,
+                    client_type,
+                    auth_mode,
+                    str(certificate_path) if certificate_path else None,
+                    str(key_path) if key_path else None,
+                    certificate_password,
+                    procuracao_token,
+                ),
+            )
+
+    def list_clients(self) -> List[Client]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT document, name, client_type, auth_mode, certificate_path, key_path, "
+                "certificate_password, procuracao_token, last_status, last_checked FROM clients"
+            ).fetchall()
+        clients: List[Client] = []
+        for row in rows:
+            last_checked = (
+                datetime.fromisoformat(row["last_checked"]) if row["last_checked"] else None
+            )
+            clients.append(
+                Client(
+                    document=row["document"],
+                    name=row["name"],
+                    client_type=row["client_type"],
+                    auth_mode=row["auth_mode"],
+                    certificate_path=Path(row["certificate_path"])
+                    if row["certificate_path"]
+                    else None,
+                    key_path=Path(row["key_path"]) if row["key_path"] else None,
+                    certificate_password=row["certificate_password"],
+                    procuracao_token=row["procuracao_token"],
+                    last_status=row["last_status"],
+                    last_checked=last_checked,
+                )
+            )
+        return clients
+
+    def get_client(self, document: str) -> Optional[Client]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT document, name, client_type, auth_mode, certificate_path, key_path, "
+                "certificate_password, procuracao_token, last_status, last_checked "
+                "FROM clients WHERE document = ?",
+                (document,),
+            ).fetchone()
+        if row is None:
+            return None
+        last_checked = datetime.fromisoformat(row["last_checked"]) if row["last_checked"] else None
+        return Client(
+            document=row["document"],
+            name=row["name"],
+            client_type=row["client_type"],
+            auth_mode=row["auth_mode"],
+            certificate_path=Path(row["certificate_path"]) if row["certificate_path"] else None,
+            key_path=Path(row["key_path"]) if row["key_path"] else None,
+            certificate_password=row["certificate_password"],
+            procuracao_token=row["procuracao_token"],
+            last_status=row["last_status"],
+            last_checked=last_checked,
+        )
+
+    def update_status(self, document: str, status: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE clients SET last_status = ?, last_checked = ? WHERE document = ?",
+                (status, datetime.utcnow().isoformat(), document),
+            )
+
+    def register_events(self, document: str, events: Sequence[Dict]) -> List[Dict]:
+        """Registra eventos inéditos e retorna apenas os novos."""
+
+        if not events:
+            return []
+
+        created: List[Dict] = []
+        with self._connect() as conn:
+            for event in events:
+                normalized = json.dumps(event, sort_keys=True, ensure_ascii=False)
+                event_hash = hashlib.sha1(normalized.encode("utf-8")).hexdigest()
+                try:
+                    conn.execute(
+                        """
+                        INSERT INTO events (client_document, event_hash, payload, received_at)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        (
+                            document,
+                            event_hash,
+                            normalized,
+                            datetime.utcnow().isoformat(),
+                        ),
+                    )
+                except sqlite3.IntegrityError:
+                    continue
+                created.append(event)
+        return created
+
+    def list_events(
+        self,
+        document: Optional[str] = None,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[EventRecord]:
+        query = (
+            "SELECT e.id, e.client_document, e.payload, e.received_at, c.name as client_name "
+            "FROM events e "
+            "LEFT JOIN clients c ON c.document = e.client_document "
+            + ("WHERE e.client_document = ? " if document else "")
+            + "ORDER BY datetime(e.received_at) DESC, e.id DESC LIMIT ? OFFSET ?"
+        )
+        params: List[Any]
+        if document:
+            params = [document, limit, offset]
+        else:
+            params = [limit, offset]
+        with self._connect() as conn:
+            rows = conn.execute(query, params).fetchall()
+        events: List[EventRecord] = []
+        for row in rows:
+            try:
+                payload = json.loads(row["payload"])
+            except json.JSONDecodeError:
+                payload = {"raw": row["payload"]}
+            events.append(
+                EventRecord(
+                    id=row["id"],
+                    client_document=row["client_document"],
+                    payload=payload,
+                    received_at=datetime.fromisoformat(row["received_at"]),
+                    client_name=row["client_name"],
+                )
+            )
+        return events
+
+    def get_dashboard_metrics(self) -> DashboardMetrics:
+        with self._connect() as conn:
+            total_clients = conn.execute("SELECT COUNT(*) FROM clients").fetchone()[0]
+            type_counts = {
+                row["client_type"]: row["count"]
+                for row in conn.execute(
+                    "SELECT client_type, COUNT(*) as count FROM clients GROUP BY client_type"
+                ).fetchall()
+            }
+            last_check_raw = conn.execute("SELECT MAX(last_checked) FROM clients").fetchone()[0]
+            total_events = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+            clients_with_alerts = conn.execute(
+                "SELECT COUNT(DISTINCT client_document) FROM events"
+            ).fetchone()[0]
+            last_event_raw = conn.execute("SELECT MAX(received_at) FROM events").fetchone()[0]
+
+        last_check = (
+            datetime.fromisoformat(last_check_raw) if last_check_raw else None
+        )
+        last_event = (
+            datetime.fromisoformat(last_event_raw) if last_event_raw else None
+        )
+        return DashboardMetrics(
+            total_clients=total_clients,
+            pj_clients=type_counts.get("PJ", 0),
+            pf_clients=type_counts.get("PF", 0),
+            total_events=total_events,
+            clients_with_alerts=clients_with_alerts,
+            last_check=last_check,
+            last_event=last_event,
+        )
+
+    def delete_client(self, document: str) -> None:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM events WHERE client_document = ?", (document,))
+            deleted = conn.execute("DELETE FROM clients WHERE document = ?", (document,)).rowcount
+        if not deleted:
+            raise ValueError(f"Cliente {document} não encontrado")
+
+    def update_client(self, document: str, **fields: Any) -> None:
+        current = self.get_client(document)
+        if not current:
+            raise ValueError(f"Cliente {document} não encontrado")
+
+        new_auth_mode = fields.get("auth_mode", current.auth_mode)
+        if new_auth_mode not in AUTH_MODES:
+            raise ValueError(f"Modo de autenticação inválido: {new_auth_mode}")
+
+        new_certificate = fields.get("certificate_path", current.certificate_path)
+        new_key = fields.get("key_path", current.key_path)
+
+        if new_auth_mode == "certificate" and (not new_certificate or not new_key):
+            raise ValueError(
+                "Certificado e chave são obrigatórios quando o modo é 'certificate'"
+            )
+        if new_auth_mode == "procuracao":
+            fields.setdefault("certificate_path", None)
+            fields.setdefault("key_path", None)
+            fields.setdefault("certificate_password", None)
+
+        allowed = {
+            "name": "name",
+            "client_type": "client_type",
+            "auth_mode": "auth_mode",
+            "certificate_path": "certificate_path",
+            "key_path": "key_path",
+            "certificate_password": "certificate_password",
+            "procuracao_token": "procuracao_token",
+        }
+        assignments: List[str] = []
+        values: List[Any] = []
+        for key, column in allowed.items():
+            if key not in fields:
+                continue
+            assignments.append(f"{column} = ?")
+            value = fields[key]
+            if isinstance(value, Path):
+                value = str(value)
+            values.append(value)
+        if not assignments:
+            return
+        values.append(document)
+        with self._connect() as conn:
+            updated = conn.execute(
+                f"UPDATE clients SET {', '.join(assignments)} WHERE document = ?",
+                values,
+            ).rowcount
+        if not updated:
+            raise ValueError(f"Cliente {document} não encontrado")
+
+
+class EcacAPIClient:
+    """Cliente HTTP que interage com a API proprietária."""
+
+    def __init__(self, config: MonitorConfig) -> None:
+        self.config = config
+
+    def _prepare_session(
+        self, client: Client, verify_ssl: bool
+    ) -> requests.Session:
+        session = requests.Session()
+        session.verify = verify_ssl
+        if client.auth_mode == "certificate" and client.certificate_path and client.key_path:
+            session.cert = (str(client.certificate_path), str(client.key_path))
+            if client.certificate_password:
+                session.headers["X-Certificate-Pin"] = client.certificate_password
+        session.headers.update({
+            "User-Agent": "ecac-monitor/1.0",
+            "X-Contador-Documento": self.config.contador_document,
+            "X-Procuracao-Token": client.procuracao_token or self.config.procuracao_token,
+        })
+        return session
+
+    def authenticate(self, session: requests.Session, client: Client) -> str:
+        if client.auth_mode == "procuracao":
+            endpoint = f"{self.config.api_base_url}/auth/procuracao"
+            payload = {
+                "document": client.document,
+                "client_type": client.client_type,
+                "contador_document": self.config.contador_document,
+            }
+            if client.procuracao_token:
+                payload["procuracao_token"] = client.procuracao_token
+        else:
+            endpoint = f"{self.config.api_base_url}/auth/certificate"
+            payload = {
+                "document": client.document,
+                "client_type": client.client_type,
+            }
+        response = session.post(
+            endpoint,
+            timeout=self.config.timeout,
+            json=payload,
+        )
+        response.raise_for_status()
+        data = response.json()
+        token = data.get("access_token")
+        if not token:
+            raise RuntimeError("Resposta da API sem access_token")
+        return token
+
+    def fetch_notifications(
+        self, session: requests.Session, token: str, document: str
+    ) -> List[Dict]:
+        response = session.get(
+            f"{self.config.api_base_url}/ecac/{document}/notifications",
+            timeout=self.config.timeout,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        notifications = payload.get("notifications")
+        if notifications is None:
+            raise RuntimeError("Resposta inesperada da API: campo 'notifications' ausente")
+        if not isinstance(notifications, list):
+            raise RuntimeError("Campo 'notifications' deve ser uma lista")
+        return notifications
+
+    def fetch_obligations(
+        self, session: requests.Session, token: str, document: str
+    ) -> List[Dict]:
+        response = session.get(
+            f"{self.config.api_base_url}/ecac/{document}/obligations",
+            timeout=self.config.timeout,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        obligations = payload.get("obligations", [])
+        if not isinstance(obligations, list):
+            raise RuntimeError("Campo 'obligations' deve ser uma lista")
+        return obligations
+
+
+class AlertDispatcher:
+    def __init__(self, webhook_url: Optional[str], verify_ssl: bool, timeout: int) -> None:
+        self.webhook_url = webhook_url
+        self.verify_ssl = verify_ssl
+        self.timeout = timeout
+
+    def dispatch(self, payload: Dict) -> None:
+        if not self.webhook_url:
+            return
+        response = requests.post(
+            self.webhook_url,
+            json=payload,
+            timeout=self.timeout,
+            verify=self.verify_ssl,
+        )
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            LOGGER.exception("Falha ao enviar alerta para %s", self.webhook_url)
+            raise
+
+
+class EcacMonitor:
+    def __init__(
+        self,
+        db: DatabaseManager,
+        api_client: EcacAPIClient,
+        dispatcher: AlertDispatcher,
+        poll_interval: int,
+        verify_ssl: bool,
+    ) -> None:
+        self.db = db
+        self.api_client = api_client
+        self.dispatcher = dispatcher
+        self.poll_interval = poll_interval
+        self.verify_ssl = verify_ssl
+
+    def run_forever(self) -> None:
+        LOGGER.info("Monitoramento iniciado")
+        while True:
+            start = time.monotonic()
+            self.run_cycle()
+            elapsed = time.monotonic() - start
+            sleep_time = max(self.poll_interval - elapsed, 5)
+            LOGGER.debug("Aguardando %.1f segundos até o próximo ciclo", sleep_time)
+            time.sleep(sleep_time)
+
+    def run_cycle(self) -> None:
+        for client in self.db.list_clients():
+            self._process_client(client)
+
+    def run_for_client(self, document: str) -> None:
+        client = self.db.get_client(document)
+        if not client:
+            raise ValueError(f"Cliente {document} não encontrado")
+        self._process_client(client)
+
+    def _process_client(self, client: Client) -> None:
+        LOGGER.info("Verificando %s (%s)", client.name, client.document)
+        session = self.api_client._prepare_session(client, self.verify_ssl)
+        try:
+            token = self.api_client.authenticate(session, client)
+            notifications = self.api_client.fetch_notifications(session, token, client.document)
+            obligations = self.api_client.fetch_obligations(session, token, client.document)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.exception("Falha ao comunicar com a API do eCAC: %s", exc)
+            return
+
+        new_events = self.db.register_events(client.document, notifications)
+        status_payload = {
+            "notifications": notifications,
+            "obligations": obligations,
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+        self.db.update_status(client.document, json.dumps(status_payload, ensure_ascii=False))
+
+        if new_events:
+            LOGGER.info("%s novos eventos encontrados para %s", len(new_events), client.document)
+            self._emit_alert(client, new_events, obligations)
+        else:
+            LOGGER.info("Nenhum evento novo para %s", client.document)
+
+    def _emit_alert(
+        self,
+        client: Client,
+        new_events: Iterable[Dict],
+        obligations: Sequence[Dict],
+    ) -> None:
+        payload = {
+            "client": {
+                "document": client.document,
+                "name": client.name,
+                "type": client.client_type,
+            },
+            "new_notifications": list(new_events),
+            "open_obligations": obligations,
+            "generated_at": datetime.utcnow().isoformat(),
+        }
+        try:
+            self.dispatcher.dispatch(payload)
+        except Exception:  # noqa: BLE001
+            LOGGER.exception("Erro ao enviar alerta do cliente %s", client.document)
+
+
+# ---------------------------------------------------------------------------
+# Linha de comando
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Monitoramento contínuo do eCAC")
+    parser.add_argument(
+        "--database",
+        default="monitor.db",
+        help="Caminho do arquivo SQLite (padrão: monitor.db)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_client_cmd = subparsers.add_parser("add-client", help="Cadastra um novo cliente")
+    add_client_cmd.add_argument("document", help="CPF ou CNPJ do contribuinte")
+    add_client_cmd.add_argument("name", help="Nome ou razão social")
+    add_client_cmd.add_argument("client_type", choices=["PJ", "PF"], help="Tipo do cliente")
+    add_client_cmd.add_argument(
+        "certificate",
+        nargs="?",
+        default=None,
+        help="Arquivo PEM do certificado da empresa (obrigatório para auth_mode=certificate)",
+    )
+    add_client_cmd.add_argument(
+        "key",
+        nargs="?",
+        default=None,
+        help="Arquivo PEM da chave privada correspondente",
+    )
+    add_client_cmd.add_argument(
+        "--auth-mode",
+        choices=sorted(AUTH_MODES),
+        default="certificate",
+        help="Define se o acesso usa certificado ou procuração (padrão: certificate)",
+    )
+    add_client_cmd.add_argument(
+        "--certificate-password",
+        dest="certificate_password",
+        help="Senha do certificado (se aplicável)",
+    )
+    add_client_cmd.add_argument(
+        "--procuracao-token",
+        dest="procuracao_token",
+        help="Token de procuração específico do cliente (opcional)",
+    )
+
+    subparsers.add_parser("list-clients", help="Lista clientes cadastrados")
+
+    update_client_cmd = subparsers.add_parser(
+        "update-client", help="Atualiza informações de um cliente"
+    )
+    update_client_cmd.add_argument("document", help="CPF ou CNPJ do contribuinte")
+    update_client_cmd.add_argument("--name", help="Novo nome ou razão social")
+    update_client_cmd.add_argument(
+        "--client-type",
+        choices=["PJ", "PF"],
+        dest="client_type",
+        help="Atualiza o tipo do cliente",
+    )
+    update_client_cmd.add_argument(
+        "--auth-mode",
+        choices=sorted(AUTH_MODES),
+        dest="auth_mode",
+        help="Altera o modo de autenticação do cliente",
+    )
+    update_client_cmd.add_argument("--certificate", help="Novo caminho do certificado")
+    update_client_cmd.add_argument("--key", help="Novo caminho da chave privada")
+    update_client_cmd.add_argument(
+        "--certificate-password",
+        dest="certificate_password",
+        help="Atualiza a senha do certificado",
+    )
+    update_client_cmd.add_argument(
+        "--procuracao-token",
+        dest="procuracao_token",
+        help="Atualiza o token de procuração",
+    )
+    update_client_cmd.add_argument(
+        "--clear-certificate-password",
+        action="store_true",
+        help="Remove a senha do certificado armazenada",
+    )
+    update_client_cmd.add_argument(
+        "--clear-procuracao-token",
+        action="store_true",
+        help="Remove o token de procuração armazenado",
+    )
+
+    delete_client_cmd = subparsers.add_parser(
+        "delete-client", help="Remove um cliente e seu histórico"
+    )
+    delete_client_cmd.add_argument("document", help="CPF ou CNPJ do contribuinte")
+
+    events_cmd = subparsers.add_parser(
+        "list-events", help="Lista eventos registrados no banco"
+    )
+    events_cmd.add_argument(
+        "--document",
+        help="Filtra eventos por documento do cliente",
+    )
+    events_cmd.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Quantidade máxima de eventos (padrão: 50)",
+    )
+    events_cmd.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Deslocamento para paginação (padrão: 0)",
+    )
+
+    status_cmd = subparsers.add_parser(
+        "show-status", help="Mostra o último status consolidado de um cliente"
+    )
+    status_cmd.add_argument("document", help="CPF ou CNPJ do contribuinte")
+
+    run_cmd = subparsers.add_parser("run", help="Executa o monitoramento contínuo")
+    run_cmd.add_argument(
+        "--config",
+        required=True,
+        help="Arquivo JSON com configuração do monitor",
+    )
+    run_cmd.add_argument(
+        "--once",
+        action="store_true",
+        help="Executa apenas um ciclo de consulta (útil para integrações)",
+    )
+    run_cmd.add_argument(
+        "--client",
+        help="Documento de um cliente específico para executar o ciclo",
+    )
+
+    return parser
+
+
+def handle_add_client(args: argparse.Namespace, db: DatabaseManager) -> None:
+    certificate_path = Path(args.certificate).expanduser() if args.certificate else None
+    key_path = Path(args.key).expanduser() if args.key else None
+    db.add_client(
+        document=args.document,
+        name=args.name,
+        client_type=args.client_type,
+        auth_mode=args.auth_mode,
+        certificate_path=certificate_path,
+        key_path=key_path,
+        certificate_password=args.certificate_password,
+        procuracao_token=args.procuracao_token,
+    )
+    LOGGER.info("Cliente %s cadastrado com sucesso", args.document)
+
+
+def handle_list_clients(db: DatabaseManager) -> None:
+    clients = db.list_clients()
+    if not clients:
+        print("Nenhum cliente cadastrado.")
+        return
+    for client in clients:
+        last_checked = client.last_checked.isoformat() if client.last_checked else "nunca"
+        print(
+            f"{client.document} | {client.name} | {client.client_type} | "
+            f"última verificação: {last_checked}"
+        )
+
+
+def handle_update_client(args: argparse.Namespace, db: DatabaseManager) -> None:
+    fields: Dict[str, Any] = {}
+    if args.name:
+        fields["name"] = args.name
+    if args.client_type:
+        fields["client_type"] = args.client_type
+    if args.auth_mode:
+        fields["auth_mode"] = args.auth_mode
+    if args.certificate:
+        fields["certificate_path"] = Path(args.certificate).expanduser()
+    if args.key:
+        fields["key_path"] = Path(args.key).expanduser()
+    if args.certificate_password is not None:
+        fields["certificate_password"] = args.certificate_password
+    if args.procuracao_token is not None:
+        fields["procuracao_token"] = args.procuracao_token
+    if args.clear_certificate_password:
+        fields["certificate_password"] = None
+    if args.clear_procuracao_token:
+        fields["procuracao_token"] = None
+    if not fields:
+        LOGGER.info("Nenhum campo informado para atualização")
+        return
+    db.update_client(args.document, **fields)
+    LOGGER.info("Cliente %s atualizado com sucesso", args.document)
+
+
+def handle_delete_client(args: argparse.Namespace, db: DatabaseManager) -> None:
+    db.delete_client(args.document)
+    LOGGER.info("Cliente %s removido", args.document)
+
+
+def handle_list_events(args: argparse.Namespace, db: DatabaseManager) -> None:
+    events = db.list_events(args.document, limit=args.limit, offset=args.offset)
+    if not events:
+        print("Nenhum evento encontrado.")
+        return
+    for event in events:
+        print(
+            f"[{event.received_at.isoformat()}] {event.client_document} - "
+            f"payload: {json.dumps(event.payload, ensure_ascii=False)}"
+        )
+
+
+def handle_show_status(args: argparse.Namespace, db: DatabaseManager) -> None:
+    client = db.get_client(args.document)
+    if not client:
+        print(f"Cliente {args.document} não encontrado.")
+        return
+    if not client.last_status:
+        print("Nenhum status registrado. Execute um ciclo de monitoramento.")
+        return
+    try:
+        status = json.loads(client.last_status)
+    except json.JSONDecodeError:
+        print(client.last_status)
+        return
+    print(json.dumps(status, indent=2, ensure_ascii=False))
+
+
+def handle_run(args: argparse.Namespace, db: DatabaseManager) -> None:
+    config = MonitorConfig.load(Path(args.config))
+    api_client = EcacAPIClient(config)
+    dispatcher = AlertDispatcher(config.webhook_url, config.verify_ssl, config.timeout)
+    monitor = EcacMonitor(db, api_client, dispatcher, config.poll_interval, config.verify_ssl)
+    if args.client:
+        monitor.run_for_client(args.client)
+        return
+    if args.once:
+        monitor.run_cycle()
+    else:
+        monitor.run_forever()
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    db = DatabaseManager(Path(args.database))
+
+    if args.command == "add-client":
+        handle_add_client(args, db)
+        return 0
+    if args.command == "list-clients":
+        handle_list_clients(db)
+        return 0
+    if args.command == "update-client":
+        handle_update_client(args, db)
+        return 0
+    if args.command == "delete-client":
+        handle_delete_client(args, db)
+        return 0
+    if args.command == "list-events":
+        handle_list_events(args, db)
+        return 0
+    if args.command == "show-status":
+        handle_show_status(args, db)
+        return 0
+    if args.command == "run":
+        handle_run(args, db)
+        return 0
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/monitor_config.example.json
+++ b/monitor_config.example.json
@@ -1,7 +1,7 @@
 {
-  "api_base_url": "https://sua-api-interna.exemplo.com",
-  "contador_document": "00000000000",
-  "procuracao_token": "token-gerado-no-ecac-para-o-contador",
+  "api_base_url": "http://localhost:5000",
+  "contador_document": "97121215187",
+  "procuracao_token": "token-padrao-procuracao",
   "poll_interval": 900,
   "verify_ssl": true,
   "timeout": 60,

--- a/monitor_config.example.json
+++ b/monitor_config.example.json
@@ -1,0 +1,9 @@
+{
+  "api_base_url": "https://sua-api-interna.exemplo.com",
+  "contador_document": "00000000000",
+  "procuracao_token": "token-gerado-no-ecac-para-o-contador",
+  "poll_interval": 900,
+  "verify_ssl": true,
+  "timeout": 60,
+  "webhook_url": "https://seu-servidor-de-alertas.exemplo.com/ecac"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31.0
+Flask>=2.3.0

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,0 +1,218 @@
+:root {
+  --card-shadow: 0 15px 35px rgba(10, 10, 10, 0.1);
+}
+
+.hero-compact {
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.hero-dashboard .hero-body {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+.stat-card {
+  background: linear-gradient(135deg, #3273dc, #23d160);
+  border-radius: 12px;
+  box-shadow: var(--card-shadow);
+  color: #fff;
+  padding: 1.75rem;
+  height: 100%;
+}
+
+.stat-card.is-secondary {
+  background: linear-gradient(135deg, #00c4a7, #209cee);
+}
+
+.stat-card.is-danger {
+  background: linear-gradient(135deg, #ff3860, #ff9f43);
+}
+
+.stat-card .stat-title {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.75rem;
+  opacity: 0.9;
+}
+
+.stat-card .stat-value {
+  font-size: 2.5rem;
+  font-weight: 700;
+}
+
+.stat-card .stat-footnote {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.notifications-stack > .notification + .notification {
+  margin-top: 0.75rem;
+}
+
+.dashboard-card {
+  border-radius: 12px;
+  box-shadow: var(--card-shadow);
+}
+
+.dashboard-card .card-header {
+  border-bottom: none;
+}
+
+.dashboard-card .card-content {
+  padding: 1.5rem;
+}
+
+.timeline {
+  position: relative;
+  padding-left: 1.75rem;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  left: 0.55rem;
+  width: 2px;
+  background: linear-gradient(180deg, #3273dc, rgba(50, 115, 220, 0));
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 1.75rem;
+}
+
+.timeline-item:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-marker {
+  position: absolute;
+  left: -1.5rem;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background-color: #3273dc;
+  box-shadow: 0 0 0 4px rgba(50, 115, 220, 0.15);
+  top: 0.35rem;
+}
+
+.timeline-content {
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: var(--card-shadow);
+  padding: 1.25rem 1.5rem;
+}
+
+.timeline-content .heading {
+  color: #7a7a7a;
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
+}
+
+.timeline-content .title {
+  margin-bottom: 0.5rem;
+}
+
+.timeline-content .tag + .tag {
+  margin-left: 0.5rem;
+}
+
+.payload-preview {
+  background: #0a0a0a;
+  border-radius: 8px;
+  color: #f5f5f5;
+  padding: 1rem;
+  overflow: auto;
+}
+
+.payload-preview code,
+.payload-preview pre {
+  background: transparent;
+  color: inherit;
+  font-family: "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-size: 0.85rem;
+}
+
+.quick-actions .button {
+  margin-bottom: 0.5rem;
+  width: 100%;
+}
+
+.quick-actions form {
+  width: 100%;
+}
+
+.quick-actions form .button {
+  width: 100%;
+}
+
+.meta-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.meta-list li + li {
+  margin-top: 0.5rem;
+}
+
+.meta-list strong {
+  display: inline-block;
+  min-width: 120px;
+}
+
+.empty-state {
+  align-items: center;
+  border: 2px dashed #b5b5b5;
+  border-radius: 10px;
+  display: flex;
+  justify-content: center;
+  min-height: 160px;
+  padding: 2rem;
+  text-align: center;
+}
+
+.details-block {
+  border-radius: 12px;
+  box-shadow: var(--card-shadow);
+  padding: 1.5rem;
+}
+
+.details-block + .details-block {
+  margin-top: 1.5rem;
+}
+
+.details-block h3 {
+  margin-bottom: 1rem;
+}
+
+.raw-status details {
+  margin-top: 1rem;
+}
+
+.raw-status summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .stat-card {
+    margin-bottom: 1.25rem;
+  }
+
+  .quick-actions .button {
+    margin-bottom: 0.75rem;
+  }
+
+  .timeline::before {
+    left: 0.35rem;
+  }
+
+  .timeline-marker {
+    left: -1.75rem;
+  }
+}

--- a/templates/add_client.html
+++ b/templates/add_client.html
@@ -1,0 +1,113 @@
+{% extends 'base.html' %}
+{% block title %}Novo cliente - Monitor eCAC{% endblock %}
+
+{% block hero %}
+<section class="hero is-success hero-compact">
+  <div class="hero-body">
+    <div class="container">
+      <p class="title">Cadastrar novo cliente</p>
+      <p class="subtitle">Informe os dados do certificado ou utilize apenas a procuração eletrônica do escritório para habilitar o monitoramento automático.</p>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<div class="columns is-variable is-6">
+  <div class="column is-two-thirds">
+    <form action="{{ url_for('create_client') }}" method="post" class="box">
+      <div class="field">
+        <label class="label">Documento</label>
+        <div class="control">
+          <input class="input" type="text" name="document" required placeholder="CPF ou CNPJ">
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Nome / Razão Social</label>
+        <div class="control">
+          <input class="input" type="text" name="name" required>
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Tipo de cliente</label>
+        <div class="control">
+          <div class="select is-fullwidth">
+            <select name="client_type" required>
+              <option value="PJ">Pessoa Jurídica</option>
+              <option value="PF">Pessoa Física</option>
+            </select>
+          </div>
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Modo de autenticação</label>
+        <div class="control">
+          <div class="select is-fullwidth">
+            <select name="auth_mode">
+              {% for mode in auth_modes %}
+              <option value="{{ mode }}" {% if mode == 'certificate' %}selected{% endif %}>
+                {% if mode == 'certificate' %}
+                  Certificado do contribuinte
+                {% else %}
+                  Procuração do contador
+                {% endif %}
+              </option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+        <p class="help">Escolha entre usar o certificado A1 do cliente ou apenas a procuração eletrônica habilitada na API.</p>
+      </div>
+      <div class="field">
+        <label class="label">Certificado (arquivo PEM)</label>
+        <div class="control">
+          <input class="input" type="text" name="certificate" placeholder="/caminho/certificado.pem">
+        </div>
+        <p class="help">Obrigatório apenas quando o modo de autenticação for certificado.</p>
+      </div>
+      <div class="field">
+        <label class="label">Chave privada (arquivo PEM)</label>
+        <div class="control">
+          <input class="input" type="text" name="key" placeholder="/caminho/chave.pem">
+        </div>
+        <p class="help">Obrigatório apenas quando o modo de autenticação for certificado.</p>
+      </div>
+      <div class="field">
+        <label class="label">Senha do certificado</label>
+        <div class="control">
+          <input class="input" type="password" name="certificate_password" placeholder="Opcional">
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Token de procuração específica</label>
+        <div class="control">
+          <input class="input" type="text" name="procuracao_token" placeholder="Opcional">
+        </div>
+      </div>
+      <div class="field is-grouped">
+        <div class="control">
+          <button class="button is-link" type="submit">Salvar cliente</button>
+        </div>
+        <div class="control">
+          <a class="button is-light" href="{{ url_for('index') }}">Cancelar</a>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div class="column is-one-third">
+    <div class="details-block">
+      <h3 class="title is-5">Dicas importantes</h3>
+      <ul class="meta-list">
+        <li><strong>Certificado:</strong> utilize arquivos no formato PEM já convertidos a partir do A1 quando optar pelo modo com certificado.</li>
+        <li><strong>Procuração:</strong> ao usar apenas a procuração, confirme se o token geral ou específico está ativo.</li>
+        <li><strong>Permissões:</strong> valide se o contador possui procuração eletrônica ativa no eCAC.</li>
+        <li><strong>Ambiente:</strong> mantenha os arquivos em diretório seguro e com permissões restritas.</li>
+      </ul>
+    </div>
+    <div class="details-block" style="margin-top: 1.5rem;">
+      <h3 class="title is-5">Próximos passos</h3>
+      <p class="is-size-6">Após salvar o cliente, execute um ciclo manual para validar a comunicação com a API e revisar os eventos iniciais.</p>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8">
+    <title>{% block title %}Monitor eCAC{% endblock %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"
+    >
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      integrity="sha512-SzlrxWriC3xO3c6t1QXSf56Z3V1LdgY6sM1U9wNXjwELyhlHLLJoPLD114F8C1ZySb9p8Anynw6L9X9+YxFeg=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    >
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
+  </head>
+  <body>
+    <nav class="navbar is-dark" role="navigation" aria-label="main navigation">
+      <div class="navbar-brand">
+        <a class="navbar-item has-text-weight-semibold" href="{{ url_for('index') }}">
+          <span class="icon-text">
+            <span class="icon">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="currentColor">
+                <path d="M12 3a9 9 0 1 0 9 9 9.01 9.01 0 0 0-9-9Zm0 16a7 7 0 1 1 7-7 7.01 7.01 0 0 1-7 7Zm1-7h3v2h-5V7h2Z" />
+              </svg>
+            </span>
+            <span>Monitor eCAC</span>
+          </span>
+        </a>
+        <a
+          role="button"
+          class="navbar-burger"
+          aria-label="menu"
+          aria-expanded="false"
+          data-target="navbarMain"
+        >
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+        </a>
+      </div>
+      <div id="navbarMain" class="navbar-menu">
+        <div class="navbar-start">
+          <a class="navbar-item" href="{{ url_for('index') }}">Painel</a>
+          <a class="navbar-item" href="{{ url_for('new_client') }}">Cadastrar cliente</a>
+        </div>
+        <div class="navbar-end">
+          <div class="navbar-item">
+            {% if config_available %}
+              <span class="tag is-success is-light">
+                Configuração carregada
+              </span>
+            {% else %}
+              <span class="tag is-warning is-light">
+                Configuração não encontrada
+              </span>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    {% block hero %}
+    <section class="hero is-primary hero-compact">
+      <div class="hero-body">
+        <div class="container">
+          <p class="title">Monitoramento do eCAC</p>
+          <p class="subtitle">Controle centralizado das notificações fiscais dos clientes.</p>
+        </div>
+      </div>
+    </section>
+    {% endblock %}
+
+    <main class="section">
+      <div class="container">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+          {% if messages %}
+            <div class="notifications-stack">
+              {% for category, message in messages %}
+                <div class="notification is-{{ 'danger' if category == 'error' else category }}">
+                  {{ message }}
+                </div>
+              {% endfor %}
+            </div>
+          {% endif %}
+        {% endwith %}
+        {% block content %}{% endblock %}
+      </div>
+    </main>
+
+    <footer class="footer">
+      <div class="content has-text-centered">
+        <p>
+          <strong>Monitor eCAC</strong> — Automação completa para escritórios de contabilidade.
+          Utilize este painel para acompanhar certificados, obrigações e alertas em tempo real.
+        </p>
+      </div>
+    </footer>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const burgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
+        burgers.forEach((el) => {
+          el.addEventListener('click', () => {
+            const target = el.dataset.target;
+            const $target = document.getElementById(target);
+            el.classList.toggle('is-active');
+            $target.classList.toggle('is-active');
+          });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/templates/client_detail.html
+++ b/templates/client_detail.html
@@ -1,0 +1,153 @@
+{% extends 'base.html' %}
+{% block title %}{{ client.name }} - Monitor eCAC{% endblock %}
+
+{% block hero %}
+<section class="hero is-info hero-compact">
+  <div class="hero-body">
+    <div class="container">
+      <p class="title">{{ client.name }}</p>
+      <p class="subtitle">{{ client.document }} · {{ 'Empresa' if client.client_type == 'PJ' else 'Pessoa Física' }}</p>
+      <div class="tags">
+        <span class="tag is-light">Última verificação:
+          {% if client.last_checked %}
+            {{ client.last_checked.strftime('%d/%m/%Y %H:%M') }}
+          {% else %}
+            nunca
+          {% endif %}
+        </span>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<div class="columns is-variable is-6">
+  <div class="column is-two-thirds">
+    <div class="details-block">
+      <h3 class="title is-5">Dados do cadastro</h3>
+      <p><strong>Documento:</strong> {{ client.document }}</p>
+      <p><strong>Tipo:</strong> {{ 'Pessoa Jurídica' if client.client_type == 'PJ' else 'Pessoa Física' }}</p>
+      <p><strong>Modo de autenticação:</strong>
+        {% if client.auth_mode == 'certificate' %}
+          Certificado do contribuinte
+        {% else %}
+          Procuração do contador
+        {% endif %}
+      </p>
+      {% if client.certificate_path %}
+      <p><strong>Caminho do certificado:</strong> <code>{{ client.certificate_path }}</code></p>
+      {% else %}
+      <p><strong>Caminho do certificado:</strong> não aplicável</p>
+      {% endif %}
+      {% if client.key_path %}
+      <p><strong>Caminho da chave privada:</strong> <code>{{ client.key_path }}</code></p>
+      {% else %}
+      <p><strong>Caminho da chave privada:</strong> não aplicável</p>
+      {% endif %}
+      <p><strong>Token específico de procuração:</strong> {{ client.procuracao_token or 'não informado' }}</p>
+    </div>
+
+    <div class="details-block" style="margin-top: 1.5rem;">
+      <h3 class="title is-5">Status do monitoramento</h3>
+      {% if status %}
+        <div class="columns">
+          <div class="column">
+            <h4 class="title is-6">Notificações</h4>
+            {% if notifications %}
+              <ul class="meta-list">
+                {% for item in notifications %}
+                  <li>
+                    <strong>#{{ loop.index }}</strong>
+                    <div class="is-size-7">{{ (item.title or item.titulo or item.assunto or item.subject) if item is mapping else item }}</div>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              <p class="has-text-grey">Nenhuma notificação registrada.</p>
+            {% endif %}
+          </div>
+          <div class="column">
+            <h4 class="title is-6">Obrigações pendentes</h4>
+            {% if obligations %}
+              <ul class="meta-list">
+                {% for obligation in obligations %}
+                  <li>
+                    <strong>#{{ loop.index }}</strong>
+                    <div class="is-size-7">
+                      {{ (obligation.title or obligation.titulo or obligation.descricao) if obligation is mapping else obligation }}
+                    </div>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              <p class="has-text-grey">Nenhuma obrigação pendente.</p>
+            {% endif %}
+          </div>
+        </div>
+        {% if metadata %}
+          <div class="details-block" style="margin-top: 1rem;">
+            <h4 class="title is-6">Metadados</h4>
+            <ul class="meta-list">
+              {% for key, value in metadata.items() %}
+                <li><strong>{{ key }}:</strong> {{ value }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+        <div class="raw-status">
+          <details>
+            <summary>Exibir payload bruto retornado pela API</summary>
+            <div class="payload-preview" style="margin-top: 1rem;">
+              <pre><code>{{ status | tojson(indent=2, ensure_ascii=False) if status is mapping else status }}</code></pre>
+            </div>
+          </details>
+        </div>
+      {% else %}
+        <p class="has-text-grey">Nenhum status registrado. Execute um ciclo para obter informações atualizadas.</p>
+      {% endif %}
+    </div>
+  </div>
+
+  <div class="column is-one-third">
+    <div class="details-block quick-actions">
+      <h3 class="title is-5">Ações rápidas</h3>
+      <a class="button is-light" href="{{ url_for('index') }}">&larr; Voltar para o painel</a>
+      <a class="button is-info" href="{{ url_for('client_events', document=client.document) }}">Histórico de eventos</a>
+      <a class="button is-warning" href="{{ url_for('edit_client', document=client.document) }}">Editar cadastro</a>
+      <form action="{{ url_for('run_cycle_for_client', document=client.document) }}" method="post">
+        <button class="button is-primary" type="submit" {% if not config_available %}disabled{% endif %}>Rodar ciclo agora</button>
+      </form>
+      <form
+        action="{{ url_for('delete_client', document=client.document) }}"
+        method="post"
+        onsubmit="return confirm('Deseja remover este cliente e seu histórico?');"
+      >
+        <button class="button is-danger" type="submit">Excluir cliente</button>
+      </form>
+    </div>
+
+    <div class="details-block" style="margin-top: 1.5rem;">
+      <h3 class="title is-5">Últimos eventos</h3>
+      {% if recent_events %}
+        <ul class="meta-list">
+          {% for event in recent_events %}
+            <li>
+              <strong>{{ event.summary }}</strong>
+              <div class="is-size-7 has-text-grey">{{ event.received_at.strftime('%d/%m/%Y %H:%M') }}</div>
+              {% if event.description %}
+                <div class="is-size-7">{{ event.description }}</div>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+        <div class="has-text-centered" style="margin-top: 0.75rem;">
+          <a class="button is-small is-light" href="{{ url_for('client_events', document=client.document) }}">Ver histórico completo</a>
+        </div>
+      {% else %}
+        <p class="has-text-grey">Nenhum evento registrado para este cliente.</p>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/client_events.html
+++ b/templates/client_events.html
@@ -1,0 +1,111 @@
+{% extends 'base.html' %}
+{% block title %}Eventos de {{ client.name }} - Monitor eCAC{% endblock %}
+
+{% block hero %}
+<section class="hero is-link hero-compact">
+  <div class="hero-body">
+    <div class="container">
+      <p class="title">Histórico de eventos</p>
+      <p class="subtitle">{{ client.name }} · {{ client.document }}</p>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<div class="columns is-variable is-6">
+  <div class="column is-three-quarters">
+    <div class="details-block">
+      <div class="level">
+        <div class="level-left">
+          <div class="level-item">
+            <h3 class="title is-5">Linha do tempo</h3>
+          </div>
+        </div>
+        <div class="level-right">
+          <div class="buttons are-small">
+            <a class="button is-light" href="{{ url_for('client_detail', document=client.document) }}">&larr; Voltar</a>
+            <a class="button is-info" href="{{ url_for('client_events', document=client.document, limit=limit, offset=offset) }}">Atualizar</a>
+          </div>
+        </div>
+      </div>
+      {% if events %}
+        <div class="timeline">
+          {% for event in events %}
+            <div class="timeline-item">
+              <div class="timeline-marker"></div>
+              <div class="timeline-content">
+                <p class="heading">{{ event.received_at.strftime('%d/%m/%Y %H:%M:%S') }}</p>
+                <p class="title is-5">{{ event.summary }}</p>
+                <div class="tags">
+                  {% if event.category %}
+                    <span class="tag is-info is-light">{{ event.category }}</span>
+                  {% endif %}
+                  {% if event.reference %}
+                    <span class="tag is-light">Ref: {{ event.reference }}</span>
+                  {% endif %}
+                  <span class="tag is-light">ID {{ event.id }}</span>
+                </div>
+                {% if event.description %}
+                  <p style="margin-top: 0.5rem;">{{ event.description }}</p>
+                {% endif %}
+                <details style="margin-top: 1rem;">
+                  <summary>Ver payload bruto</summary>
+                  <div class="payload-preview" style="margin-top: 0.75rem;">
+                    <pre><code>{{ event.payload | tojson(indent=2, ensure_ascii=False) }}</code></pre>
+                  </div>
+                </details>
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+        <div class="buttons" style="margin-top: 1.5rem;">
+          {% if prev_offset is not none %}
+            <a class="button" href="{{ url_for('client_events', document=client.document, limit=limit, offset=prev_offset) }}">&larr; Anteriores</a>
+          {% endif %}
+          {% if next_offset is not none %}
+            <a class="button" href="{{ url_for('client_events', document=client.document, limit=limit, offset=next_offset) }}">Próximos &rarr;</a>
+          {% endif %}
+        </div>
+      {% else %}
+        <div class="empty-state">
+          <div>
+            <p class="title is-5">Nenhum evento registrado até o momento.</p>
+            <p class="subtitle is-6">Execute um ciclo de monitoramento para captar novas notificações.</p>
+          </div>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+  <div class="column is-one-quarter">
+    <div class="details-block">
+      <h3 class="title is-6">Configurações de exibição</h3>
+      <form action="{{ url_for('client_events', document=client.document) }}" method="get">
+        <div class="field">
+          <label class="label">Eventos por página</label>
+          <div class="control">
+            <div class="select is-fullwidth">
+              <select name="limit">
+                {% for option in [10, 25, 50, 100] %}
+                  <option value="{{ option }}" {% if option == limit %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="field">
+          <label class="label">Iniciar em</label>
+          <div class="control">
+            <input class="input" type="number" name="offset" value="{{ offset }}" min="0">
+          </div>
+        </div>
+        <div class="field">
+          <div class="control">
+            <button class="button is-primary is-fullwidth" type="submit">Aplicar filtros</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/edit_client.html
+++ b/templates/edit_client.html
@@ -1,0 +1,111 @@
+{% extends 'base.html' %}
+{% block title %}Editar {{ client.name }} - Monitor eCAC{% endblock %}
+
+{% block hero %}
+<section class="hero is-warning hero-compact">
+  <div class="hero-body">
+    <div class="container">
+      <p class="title">Atualizar cadastro</p>
+      <p class="subtitle">Faça ajustes de certificados, senhas, tokens ou altere o modo de autenticação sempre que houver troca de representantes ou renovação.</p>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<div class="columns is-variable is-6">
+  <div class="column is-two-thirds">
+    <form action="{{ url_for('update_client', document=client.document) }}" method="post" class="box">
+      <div class="field">
+        <label class="label">Documento</label>
+        <p class="control"><input class="input" type="text" value="{{ client.document }}" disabled></p>
+      </div>
+      <div class="field">
+        <label class="label">Nome / Razão Social</label>
+        <div class="control">
+          <input class="input" type="text" name="name" value="{{ client.name }}" required>
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Tipo de cliente</label>
+        <div class="control">
+          <div class="select is-fullwidth">
+            <select name="client_type" required>
+              <option value="PJ" {% if client.client_type == 'PJ' %}selected{% endif %}>Pessoa Jurídica</option>
+              <option value="PF" {% if client.client_type == 'PF' %}selected{% endif %}>Pessoa Física</option>
+            </select>
+          </div>
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Modo de autenticação</label>
+        <div class="control">
+          <div class="select is-fullwidth">
+            <select name="auth_mode" required>
+              {% for mode in auth_modes %}
+              <option value="{{ mode }}" {% if client.auth_mode == mode %}selected{% endif %}>
+                {% if mode == 'certificate' %}
+                  Certificado do contribuinte
+                {% else %}
+                  Procuração do contador
+                {% endif %}
+              </option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+        <p class="help">Selecione como o monitor irá autenticar no eCAC para este cliente.</p>
+      </div>
+      <div class="field">
+        <label class="label">Certificado (arquivo PEM)</label>
+        <div class="control">
+          <input class="input" type="text" name="certificate" value="{{ client.certificate_path or '' }}">
+        </div>
+        <p class="help">Informe apenas quando o modo selecionado utilizar certificado.</p>
+      </div>
+      <div class="field">
+        <label class="label">Chave privada (arquivo PEM)</label>
+        <div class="control">
+          <input class="input" type="text" name="key" value="{{ client.key_path or '' }}">
+        </div>
+        <p class="help">Obrigatória somente quando o modo for certificado.</p>
+      </div>
+      <div class="field">
+        <label class="label">Senha do certificado</label>
+        <div class="control">
+          <input class="input" type="password" name="certificate_password" value="{{ client.certificate_password or '' }}" placeholder="Opcional">
+        </div>
+      </div>
+      <div class="field">
+        <label class="label">Token de procuração específica</label>
+        <div class="control">
+          <input class="input" type="text" name="procuracao_token" value="{{ client.procuracao_token or '' }}" placeholder="Opcional">
+        </div>
+      </div>
+      <div class="field is-grouped">
+        <div class="control">
+          <button class="button is-link" type="submit">Salvar alterações</button>
+        </div>
+        <div class="control">
+          <a class="button is-light" href="{{ url_for('client_detail', document=client.document) }}">Cancelar</a>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div class="column is-one-third">
+    <div class="details-block">
+      <h3 class="title is-5">Boas práticas</h3>
+      <ul class="meta-list">
+        <li>Atualize o certificado sempre que o arquivo for substituído ou expirar.</li>
+        <li>Ao migrar para o modo por procuração, deixe os campos de certificado e chave em branco.</li>
+        <li>Ao remover a senha, deixe o campo em branco e salve.</li>
+        <li>O token de procuração pode ser individual para o cliente ou o padrão definido no arquivo de configuração.</li>
+      </ul>
+    </div>
+    <div class="details-block" style="margin-top: 1.5rem;">
+      <h3 class="title is-5">Monitoramento</h3>
+      <p class="is-size-6">Após salvar, execute um ciclo para validar o novo certificado e garantir que o escritório continue recebendo notificações.</p>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,259 @@
+{% extends 'base.html' %}
+{% block title %}Painel - Monitor eCAC{% endblock %}
+
+{% block hero %}
+<section class="hero is-primary hero-dashboard">
+  <div class="hero-body">
+    <div class="container">
+      <div class="columns is-vcentered">
+        <div class="column is-7">
+          <p class="title">Painel operacional do Monitor eCAC</p>
+          <p class="subtitle">
+            Visualize rapidamente o status dos clientes, execute ciclos sob demanda e acompanhe
+            as últimas notificações recebidas pela integração com a API proprietária.
+          </p>
+          <div class="buttons">
+            <a class="button is-light" href="{{ url_for('new_client') }}">
+              <span class="icon"><i class="fas fa-user-plus"></i></span>
+              <span>Adicionar cliente</span>
+            </a>
+            <form action="{{ url_for('run_cycle') }}" method="post">
+              <button class="button is-warning" type="submit" {% if not config_available %}disabled{% endif %}>
+                <span class="icon"><i class="fas fa-sync-alt"></i></span>
+                <span>Executar ciclo global</span>
+              </button>
+            </form>
+          </div>
+        </div>
+        <div class="column is-5">
+          <div class="columns is-multiline">
+            <div class="column is-half">
+              <div class="stat-card">
+                <p class="stat-title">Clientes monitorados</p>
+                <p class="stat-value">{{ metrics.total_clients }}</p>
+                <p class="stat-footnote">{{ metrics.pj_clients }} PJ · {{ metrics.pf_clients }} PF</p>
+              </div>
+            </div>
+            <div class="column is-half">
+              <div class="stat-card is-secondary">
+                <p class="stat-title">Eventos registrados</p>
+                <p class="stat-value">{{ metrics.total_events }}</p>
+                <p class="stat-footnote">{{ metrics.clients_with_alerts }} clientes com alertas</p>
+              </div>
+            </div>
+            <div class="column is-half">
+              <div class="stat-card is-danger">
+                <p class="stat-title">Último ciclo</p>
+                <p class="stat-value">
+                  {% if metrics.last_check %}
+                    {{ metrics.last_check.strftime('%d/%m %H:%M') }}
+                  {% else %}
+                    --
+                  {% endif %}
+                </p>
+                <p class="stat-footnote">
+                  {% if metrics.last_event %}
+                    Último evento {{ metrics.last_event.strftime('%d/%m %H:%M') }}
+                  {% else %}
+                    Nenhum evento registrado
+                  {% endif %}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block content %}
+<div class="columns is-variable is-6">
+  <div class="column is-two-thirds">
+    {% if not config_available %}
+      <article class="message is-warning">
+        <div class="message-header">Configuração ausente</div>
+        <div class="message-body">
+          Defina a variável de ambiente <code>MONITOR_CONFIG</code> apontando para o arquivo JSON
+          de configuração antes de executar um ciclo. A interface continua disponível para gestão de clientes.
+        </div>
+      </article>
+    {% endif %}
+
+    <div class="card dashboard-card">
+      <header class="card-header">
+        <p class="card-header-title">Clientes cadastrados</p>
+        <div class="card-header-icon">
+          <span class="tag is-light">{{ clients|length }} registros</span>
+        </div>
+      </header>
+      <div class="card-content">
+        <div class="table-container">
+          <table class="table is-fullwidth is-striped is-hoverable">
+            <thead>
+              <tr>
+                <th>Cliente</th>
+                <th class="is-hidden-touch">Documento</th>
+                <th>Tipo</th>
+                <th>Última verificação</th>
+                <th>Alertas</th>
+                <th class="is-narrow">Ações</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for entry in clients %}
+                {% set client = entry.client %}
+                <tr>
+                  <td>
+                    <strong>{{ client.name }}</strong>
+                    <br class="is-hidden-desktop">
+                    <small class="is-hidden-desktop has-text-grey">{{ client.document }}</small>
+                  </td>
+                  <td class="is-hidden-touch">{{ client.document }}</td>
+                  <td>
+                    <span class="tag is-rounded {{ 'is-link' if client.client_type == 'PJ' else 'is-info' }}">
+                      {{ 'Empresa' if client.client_type == 'PJ' else 'Pessoa Física' }}
+                    </span>
+                    <span class="tag is-rounded is-light" style="margin-top: 0.25rem;">
+                      {% if client.auth_mode == 'certificate' %}
+                        Certificado
+                      {% else %}
+                        Procuração
+                      {% endif %}
+                    </span>
+                  </td>
+                  <td>
+                    {% if client.last_checked %}
+                      {{ client.last_checked.strftime('%d/%m/%Y %H:%M') }}
+                    {% else %}
+                      <span class="has-text-grey">Nunca verificado</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if entry.notifications > 0 %}
+                      <span class="tag is-danger is-light">{{ entry.notifications }} notificações</span>
+                    {% else %}
+                      <span class="tag is-light">Sem alertas</span>
+                    {% endif %}
+                    {% if entry.obligations > 0 %}
+                      <span class="tag is-warning is-light">{{ entry.obligations }} obrigações</span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    <div class="buttons are-small">
+                      <a class="button is-light" href="{{ url_for('client_detail', document=client.document) }}">Detalhes</a>
+                      <a class="button is-info is-light" href="{{ url_for('client_events', document=client.document) }}">Eventos</a>
+                      <a class="button is-warning is-light" href="{{ url_for('edit_client', document=client.document) }}">Editar</a>
+                      <form action="{{ url_for('run_cycle_for_client', document=client.document) }}" method="post">
+                        <button class="button is-primary" type="submit" {% if not config_available %}disabled{% endif %}>
+                          Rodar ciclo
+                        </button>
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+              {% else %}
+                <tr>
+                  <td colspan="6">
+                    <div class="empty-state">
+                      <div>
+                        <p class="title is-5">Nenhum cliente cadastrado ainda</p>
+                        <p class="subtitle is-6">Clique em “Adicionar cliente” para iniciar o monitoramento.</p>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="column is-one-third">
+    <div class="card dashboard-card">
+      <header class="card-header">
+        <p class="card-header-title">Últimos eventos</p>
+      </header>
+      <div class="card-content">
+        {% if recent_events %}
+          <ul class="meta-list">
+            {% for event in recent_events %}
+              <li>
+                <p class="has-text-weight-semibold">{{ event.summary }}</p>
+                <p class="is-size-7 has-text-grey">
+                  {{ event.received_at.strftime('%d/%m/%Y %H:%M') }} · {{ event.client_name or event.client_document }}
+                </p>
+                {% if event.description %}
+                  <p class="is-size-7">{{ event.description }}</p>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+          <div class="has-text-centered" style="margin-top: 1rem;">
+            <a class="button is-small is-light" href="{{ url_for('client_events', document=recent_events[0].client_document) }}">
+              Ver histórico completo
+            </a>
+          </div>
+        {% else %}
+          <p class="has-text-grey">Nenhum evento recebido até o momento.</p>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="card dashboard-card" style="margin-top: 1.5rem;">
+      <header class="card-header">
+        <p class="card-header-title">Clientes a verificar</p>
+      </header>
+      <div class="card-content">
+        {% if stale_clients %}
+          <ul class="meta-list">
+            {% for entry in stale_clients %}
+              <li>
+                <strong>{{ entry.client.name }}</strong>
+                <div class="is-size-7 has-text-grey">
+                  Última verificação:
+                  {% if entry.client.last_checked %}
+                    {{ entry.client.last_checked.strftime('%d/%m/%Y %H:%M') }}
+                  {% else %}
+                    nunca
+                  {% endif %}
+                </div>
+                <form
+                  action="{{ url_for('run_cycle_for_client', document=entry.client.document) }}"
+                  method="post"
+                  style="margin-top: 0.5rem;"
+                >
+                  <button class="button is-small is-primary is-light" type="submit" {% if not config_available %}disabled{% endif %}>
+                    Verificar agora
+                  </button>
+                </form>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="has-text-grey">Todos os clientes foram verificados nas últimas 24 horas.</p>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="card dashboard-card" style="margin-top: 1.5rem;">
+      <header class="card-header">
+        <p class="card-header-title">Guia rápido de operação</p>
+      </header>
+      <div class="card-content">
+        <p class="is-size-6">
+          • Atualize certificados e tokens nas ações de cada cliente.<br>
+          • Utilize o ciclo global diário para consolidar notificações.<br>
+          • Configure o <code>MONITOR_CONFIG</code> e o <code>MONITOR_DATABASE</code> em produção.
+        </p>
+        <p class="is-size-7 has-text-grey" style="margin-top: 0.75rem;">
+          A documentação completa está no arquivo README.md do projeto.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,351 @@
+"""Aplicação web para operar o monitoramento do eCAC."""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from flask import (
+    Flask,
+    Response,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+
+from main import (
+    AUTH_MODES,
+    AlertDispatcher,
+    Client,
+    DashboardMetrics,
+    DatabaseManager,
+    EcacAPIClient,
+    EcacMonitor,
+    MonitorConfig,
+)
+
+
+def _load_config() -> MonitorConfig:
+    config_path = Path(os.environ.get("MONITOR_CONFIG", "monitor_config.json"))
+    if not config_path.exists():
+        raise FileNotFoundError(
+            "Arquivo de configuração do monitor não encontrado. "
+            "Defina MONITOR_CONFIG com o caminho correto."
+        )
+    return MonitorConfig.load(config_path)
+
+
+def _load_database() -> DatabaseManager:
+    db_path = Path(os.environ.get("MONITOR_DATABASE", "monitor.db"))
+    return DatabaseManager(db_path)
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY", "change-me")
+
+    db = _load_database()
+
+    def _build_monitor() -> EcacMonitor:
+        config = _load_config()
+        api_client = EcacAPIClient(config)
+        dispatcher = AlertDispatcher(config.webhook_url, config.verify_ssl, config.timeout)
+        return EcacMonitor(db, api_client, dispatcher, config.poll_interval, config.verify_ssl)
+
+    @app.context_processor
+    def inject_globals() -> Dict[str, Any]:
+        config_env = os.environ.get("MONITOR_CONFIG")
+        available = bool(config_env and Path(config_env).exists())
+        return {"config_available": available}
+
+    def _prepare_status(client: Client) -> Optional[Dict[str, Any]]:
+        if not client.last_status:
+            return None
+        try:
+            return json.loads(client.last_status)
+        except json.JSONDecodeError:
+            return {"raw": client.last_status}
+
+    def _format_event(event) -> Dict[str, Any]:
+        payload = event.payload
+        summary = None
+        description = None
+        category = None
+        reference = None
+        if isinstance(payload, dict):
+            for key in ("title", "titulo", "subject", "assunto"):
+                if payload.get(key):
+                    summary = str(payload[key])
+                    break
+            description = (
+                payload.get("description")
+                or payload.get("mensagem")
+                or payload.get("message")
+            )
+            category = payload.get("category") or payload.get("categoria")
+            reference = (
+                payload.get("reference")
+                or payload.get("protocolo")
+                or payload.get("id")
+            )
+        if summary is None:
+            if isinstance(payload, (str, int, float)):
+                summary = str(payload)
+            else:
+                summary = json.dumps(payload, ensure_ascii=False)
+        return {
+            "id": event.id,
+            "client_document": event.client_document,
+            "client_name": getattr(event, "client_name", None),
+            "received_at": event.received_at,
+            "summary": summary,
+            "description": description,
+            "category": category,
+            "reference": reference,
+            "payload": payload,
+        }
+
+    @app.get("/")
+    def index() -> str:
+        clients = db.list_clients()
+        metrics: DashboardMetrics = db.get_dashboard_metrics()
+        enriched = []
+        for client in clients:
+            status = _prepare_status(client)
+            notifications = 0
+            obligations = 0
+            if isinstance(status, dict):
+                notifications_field = status.get("notifications") or status.get("avisos")
+                if isinstance(notifications_field, list):
+                    notifications = len(notifications_field)
+                obligations_field = (
+                    status.get("obligations")
+                    or status.get("obrigacoes")
+                    or status.get("obrigações")
+                )
+                if isinstance(obligations_field, list):
+                    obligations = len(obligations_field)
+            enriched.append(
+                {
+                    "client": client,
+                    "status": status,
+                    "notifications": notifications,
+                    "obligations": obligations,
+                }
+            )
+
+        stale_threshold = datetime.utcnow() - timedelta(hours=24)
+        stale_clients = [
+            entry
+            for entry in enriched
+            if not entry["client"].last_checked
+            or entry["client"].last_checked < stale_threshold
+        ]
+        recent_events = [_format_event(event) for event in db.list_events(limit=6)]
+
+        return render_template(
+            "index.html",
+            clients=enriched,
+            metrics=metrics,
+            stale_clients=stale_clients,
+            recent_events=recent_events,
+        )
+
+    @app.get("/clients/new")
+    def new_client() -> str:
+        return render_template("add_client.html", auth_modes=sorted(AUTH_MODES))
+
+    @app.post("/clients")
+    def create_client() -> Response:
+        form = request.form
+        auth_mode = form.get("auth_mode", "certificate")
+        if auth_mode not in AUTH_MODES:
+            flash("Modo de autenticação inválido", "error")
+            return redirect(url_for("new_client"))
+
+        required = ["document", "name", "client_type"]
+        if auth_mode == "certificate":
+            required.extend(["certificate", "key"])
+        missing = [field for field in required if not form.get(field)]
+        if missing:
+            flash(f"Campos obrigatórios ausentes: {', '.join(missing)}", "error")
+            return redirect(url_for("new_client"))
+
+        try:
+            db.add_client(
+                document=form["document"].strip(),
+                name=form["name"].strip(),
+                client_type=form["client_type"],
+                auth_mode=auth_mode,
+                certificate_path=Path(form["certificate"]).expanduser()
+                if form.get("certificate")
+                else None,
+                key_path=Path(form["key"]).expanduser() if form.get("key") else None,
+                certificate_password=form.get("certificate_password") or None,
+                procuracao_token=form.get("procuracao_token") or None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            flash(f"Erro ao cadastrar cliente: {exc}", "error")
+            return redirect(url_for("new_client"))
+
+        flash("Cliente cadastrado com sucesso", "success")
+        return redirect(url_for("index"))
+
+    @app.get("/clients/<document>")
+    def client_detail(document: str) -> str:
+        client = db.get_client(document)
+        if not client:
+            flash("Cliente não encontrado", "error")
+            return redirect(url_for("index"))
+        status = _prepare_status(client)
+        notifications = []
+        obligations = []
+        metadata: Dict[str, Any] = {}
+        if isinstance(status, dict):
+            raw_notifications = status.get("notifications") or status.get("avisos")
+            if isinstance(raw_notifications, list):
+                notifications = raw_notifications
+            raw_obligations = (
+                status.get("obligations")
+                or status.get("obrigacoes")
+                or status.get("obrigações")
+            )
+            if isinstance(raw_obligations, list):
+                obligations = raw_obligations
+            meta_candidate = status.get("metadata") or status.get("metadados")
+            if isinstance(meta_candidate, dict):
+                metadata = meta_candidate
+        recent_events = [
+            _format_event(event) for event in db.list_events(document, limit=5)
+        ]
+        return render_template(
+            "client_detail.html",
+            client=client,
+            status=status,
+            notifications=notifications,
+            obligations=obligations,
+            metadata=metadata,
+            recent_events=recent_events,
+        )
+
+    @app.post("/run-cycle")
+    def run_cycle() -> Response:
+        try:
+            monitor = _build_monitor()
+            monitor.run_cycle()
+        except FileNotFoundError as exc:
+            flash(str(exc), "error")
+            return redirect(url_for("index"))
+        except Exception as exc:  # noqa: BLE001
+            flash(f"Erro ao executar ciclo: {exc}", "error")
+            return redirect(url_for("index"))
+
+        flash("Ciclo executado com sucesso", "success")
+        return redirect(url_for("index"))
+
+    @app.post("/clients/<document>/run")
+    def run_cycle_for_client(document: str) -> Response:
+        try:
+            monitor = _build_monitor()
+            monitor.run_for_client(document)
+        except ValueError as exc:
+            flash(str(exc), "error")
+            return redirect(url_for("index"))
+        except FileNotFoundError as exc:
+            flash(str(exc), "error")
+            return redirect(url_for("client_detail", document=document))
+        except Exception as exc:  # noqa: BLE001
+            flash(f"Erro ao executar ciclo: {exc}", "error")
+            return redirect(url_for("client_detail", document=document))
+        flash("Ciclo executado com sucesso", "success")
+        return redirect(url_for("client_detail", document=document))
+
+    @app.get("/clients/<document>/events")
+    def client_events(document: str) -> str:
+        client = db.get_client(document)
+        if not client:
+            flash("Cliente não encontrado", "error")
+            return redirect(url_for("index"))
+        try:
+            limit = max(1, min(500, int(request.args.get("limit", 50))))
+            offset = max(0, int(request.args.get("offset", 0)))
+        except ValueError:
+            flash("Parâmetros de paginação inválidos", "error")
+            return redirect(url_for("client_events", document=document))
+        events = db.list_events(document, limit=limit, offset=offset)
+        formatted_events = [_format_event(event) for event in events]
+        return render_template(
+            "client_events.html",
+            client=client,
+            events=formatted_events,
+            limit=limit,
+            offset=offset,
+            next_offset=offset + limit if len(events) == limit else None,
+            prev_offset=offset - limit if offset - limit >= 0 else None,
+        )
+
+    @app.get("/clients/<document>/edit")
+    def edit_client(document: str) -> str:
+        client = db.get_client(document)
+        if not client:
+            flash("Cliente não encontrado", "error")
+            return redirect(url_for("index"))
+        return render_template(
+            "edit_client.html", client=client, auth_modes=sorted(AUTH_MODES)
+        )
+
+    @app.post("/clients/<document>")
+    def update_client(document: str) -> Response:
+        client = db.get_client(document)
+        if not client:
+            flash("Cliente não encontrado", "error")
+            return redirect(url_for("index"))
+        form = request.form
+        fields: Dict[str, Any] = {}
+        if form.get("name"):
+            fields["name"] = form["name"].strip()
+        if form.get("client_type"):
+            fields["client_type"] = form["client_type"]
+        if form.get("auth_mode"):
+            fields["auth_mode"] = form.get("auth_mode")
+        if form.get("certificate"):
+            fields["certificate_path"] = Path(form["certificate"]).expanduser()
+        if form.get("key"):
+            fields["key_path"] = Path(form["key"]).expanduser()
+        if form.get("certificate_password") is not None:
+            fields["certificate_password"] = form.get("certificate_password") or None
+        if form.get("procuracao_token") is not None:
+            fields["procuracao_token"] = form.get("procuracao_token") or None
+        if not fields:
+            flash("Nenhuma alteração informada", "warning")
+            return redirect(url_for("edit_client", document=document))
+        try:
+            db.update_client(document, **fields)
+        except Exception as exc:  # noqa: BLE001
+            flash(f"Erro ao atualizar cliente: {exc}", "error")
+            return redirect(url_for("edit_client", document=document))
+        flash("Cliente atualizado com sucesso", "success")
+        return redirect(url_for("client_detail", document=document))
+
+    @app.post("/clients/<document>/delete")
+    def delete_client(document: str) -> Response:
+        try:
+            db.delete_client(document)
+        except ValueError as exc:
+            flash(str(exc), "error")
+            return redirect(url_for("index"))
+        flash("Cliente removido", "success")
+        return redirect(url_for("index"))
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8000)), debug=False)


### PR DESCRIPTION
## Summary
- allow each client to choose between certificate or procuracao authentication with database migrations, API session handling, and CLI support
- expose the auth mode toggle and contextual guidance across the web dashboard, including listing badges and detail views
- document the dual authentication flows in the README with updated examples and operational notes

## Testing
- python -m compileall main.py webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68e2c607c4a48329944f8f2c74d94ed8