### PR TITLE
Add goal and task summary insights to dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+dist/
+__pycache__/
+*.pyc
+bpo_finance.db
+*.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential libxml2-dev libxslt-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "bpo_app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,197 @@
+# BPO Financeiro Simples
+
+O repositório agora inclui um sistema completo para escritórios de contabilidade que desejam oferecer BPO Financeiro aos seus clientes. A solução roda em `localhost`, usa apenas tecnologias gratuitas e foi pensada para ser clara para empresários que não dominam termos contábeis.
+
+## Principais recursos
+
+- **Multiempresa**: cadastre quantas empresas quiser, cada uma com contas bancárias, categorias e usuários próprios.
+- **Perfis de acesso separados**: clientes visualizam apenas os dados da própria empresa, enquanto o escritório possui um painel com visão consolidada.
+- **Importação de extratos**: suporte a arquivos Excel (`.xlsx`), CSV e OFX com classificação automática por palavras-chave.
+- **Relatórios em linguagem simples**: Fluxo de Caixa mensal, resumo de resultado (DRE simplificada), listas de contas a pagar e receber, além de destaques que explicam a situação do negócio.
+- **Exportação**: gere relatórios em PDF ou Excel com um clique.
+- **Interface responsiva**: painel renovado com seleção de período, gráfico interativo de fluxo de caixa e listas amigáveis de contas a pagar e receber que funcionam bem em computadores e celulares.
+- **Centro de configurações**: menu moderno para o escritório administrar empresas, usuários, contas bancárias, categorias, lançamentos e importações em um único lugar.
+- **Metas financeiras claras**: defina objetivos de entrada ou redução de gastos por empresa e acompanhe o progresso com mensagens em linguagem simples.
+- **Checklist colaborativo**: registre tarefas financeiras com responsáveis, prazos e status para alinhar ações entre o escritório e o cliente.
+- **Visão consolidada de metas e checklist**: contadores automáticos destacam metas ativas, próximos prazos e tarefas pendentes diretamente no painel do cliente.
+- **Integração NFSe (ABRASF)**: envie XMLs para os principais serviços SOAP (consulta, cancelamento, geração etc.) direto do painel administrativo.
+- **Emissão NFSe Goiânia**: preencha um formulário com dados do RPS e gere automaticamente o XML padrão ABRASF usado pela Prefeitura de Goiânia para envio do `GerarNfse`.
+- **API FastAPI com SQLite**: pronta para receber uma futura migração para PostgreSQL.
+- **Containerização**: Dockerfile e Docker Compose para subir o ambiente rapidamente.
+
+## Como executar com Docker
+
+```bash
+docker compose up --build
+```
+
+O serviço ficará disponível em `http://localhost:8000`. A interface web pode ser acessada em `http://localhost:8000/`.
+
+O sistema utiliza variáveis definidas em um arquivo `.env` na raiz do projeto. Os scripts de instalação criam esse arquivo automaticamente com uma chave secreta e credenciais iniciais geradas na hora. Caso esteja configurando manualmente, crie um arquivo `.env` com, por exemplo:
+
+```
+BPO_SECRET_KEY=troque-esta-chave
+BPO_ADMIN_EMAIL=admin@bpo.local
+BPO_ADMIN_PASSWORD=uma-senha-bem-segura
+BPO_ADMIN_NAME=Administrador
+# opcional: BPO_DATABASE_URL=sqlite:///./bpo_finance.db
+# integração NFSe (preencha se desejar acionar os serviços SOAP)
+# BPO_NFSE_WSDL_URL=https://exemplo.prefeitura.gov.br/nfse?wsdl
+# BPO_NFSE_SERVICE_URL=https://exemplo.prefeitura.gov.br/nfse.asmx
+# BPO_NFSE_TIMEOUT=45
+# BPO_NFSE_VERIFY_SSL=true
+```
+
+Na primeira inicialização essas informações criam o usuário administrador. Atualize a senha após o primeiro acesso e utilize valores fortes (principalmente para `BPO_SECRET_KEY`) antes de levar o sistema para produção.
+
+## Executando sem Docker
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn bpo_app.main:app --reload
+```
+
+## Testes automatizados
+
+```bash
+python -m unittest discover
+```
+
+Os testes cobrem o fluxo principal: login, cadastro de empresa, importação de extratos e geração de relatórios.
+
+## Verificação rápida do ambiente
+
+Caso encontre erros ao iniciar o sistema ou executar os testes, rode o script de diagnóstico:
+
+```bash
+python tools/run_diagnostics.py
+```
+
+Ele confirma se todas as dependências Python estão instaladas, aponta variáveis de ambiente sensíveis ainda com valores padrão,
+verifica se o banco de dados contém pelo menos um administrador e confirma a presença dos arquivos do frontend, instaladores e
+manual. Use `--json` para gerar uma saída estruturada útil em pipelines de CI ou para compartilhar com a equipe.
+
+## Scripts de instalação automatizada
+
+Os arquivos estão organizados em `installers/` com numeração sequencial para facilitar o envio direto ao cliente:
+
+1. `installers/01_windows_installer.ps1`
+2. `installers/02_linux_installer.sh`
+
+Cada script prepara o ambiente, instala dependências e pode iniciar o servidor imediatamente.
+
+### Windows 11 (PowerShell)
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass
+cd installers
+./01_windows_installer.ps1
+```
+
+Use `-SkipRun` para instalar sem iniciar o servidor automaticamente ou ajuste host e porta com `-Host` e `-Port`.
+
+O script cria um arquivo `.env` com chave secreta e mostra na tela as credenciais iniciais do administrador.
+
+### Linux ou VPS Contábil (bash)
+
+```bash
+cd installers
+chmod +x 02_linux_installer.sh
+./02_linux_installer.sh
+```
+
+No Linux é possível evitar que o script execute o servidor adicionando `--skip-run`. Também é possível definir host e porta com `--host` e `--port`.
+
+Assim como no Windows, o script gera um `.env` com chave secreta e exibe as credenciais iniciais para você guardar.
+
+### Manual visual de instalação e uso
+
+Um guia passo a passo em formato de apresentação está disponível em `docs/manual_canva.md`. Ele pode ser compartilhado diretamente com clientes ou importado em ferramentas como Canva para customização visual.
+
+### Pacote completo para enviar ao cliente
+
+Use o comando abaixo para gerar um arquivo `.zip` com os instaladores, guia rápido, manual visual e arquivos da interface web. O pacote fica disponível em `dist/bpo_instalacao.zip` e pode ser anexado em e-mails ou compartilhado por Drive.
+
+```bash
+python tools/create_install_bundle.py
+```
+
+Se quiser personalizar o destino ou remover a interface web do pacote, consulte `docs/pacote_instalacao.md`.
+
+### Integração NFSe (ABRASF)
+
+O backend expõe a rota `POST /integrations/nfse/{operacao}` para enviar XMLs aos serviços padronizados pelo layout ABRASF. Informe o nome da operação (por exemplo, `ConsultarNfsePorRps`, `GerarNfse` ou `CancelarNfse`) e envie um JSON com o XML do cabeçalho (`nfse_cabec_msg`) e dos dados (`nfse_dados_msg`). Opcionalmente é possível sobrescrever a URL do WSDL, o endpoint do serviço, timeout e a verificação de certificado. Endereços relativos como `nfse.asmx` também são aceitos: o sistema combina automaticamente com a origem do WSDL, exatamente como em muitos modelos municipais.
+
+Exemplo de chamada:
+
+```bash
+curl -X POST "http://localhost:8000/integrations/nfse/ConsultarNfsePorRps" \
+  -H "Authorization: Bearer <TOKEN_DO_ADMIN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "nfse_cabec_msg": "<cabecalho>...</cabecalho>",
+        "nfse_dados_msg": "<dados>...</dados>",
+        "wsdl_url": "https://exemplo.prefeitura.gov.br/nfse?wsdl",
+        "service_url": "https://exemplo.prefeitura.gov.br/nfse.asmx"
+      }'
+```
+
+Se nenhum valor for enviado para `wsdl_url` ou `service_url`, o sistema utiliza as configurações definidas no `.env`. Apenas administradores ou membros da equipe interna (perfil `staff`) podem acionar essa integração.
+
+#### Emissão NFSe padrão Goiânia
+
+Para agilizar a emissão no padrão ABRASF utilizado pela Prefeitura de Goiânia, há um atalho estruturado em `POST /integrations/nfse/goiania/emissao`. Basta informar os dados do prestador, tomador e serviço em linguagem direta que o backend monta o `nfseCabecMsg` e o `nfseDadosMsg` automaticamente e envia a operação `GerarNfse`.
+
+Exemplo mínimo:
+
+```bash
+curl -X POST "http://localhost:8000/integrations/nfse/goiania/emissao" \
+  -H "Authorization: Bearer <TOKEN_DO_ADMIN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "numero_lote": "20240001",
+        "numero_rps": "15",
+        "serie_rps": "GO",
+        "data_emissao": "2024-01-10T10:30:00",
+        "prestador": {"cnpj": "12.345.678/0001-99", "inscricao_municipal": "123456"},
+        "servico": {
+            "item_lista_servico": "0701",
+            "codigo_tributacao_municipio": "070199",
+            "discriminacao": "Serviço de gestão financeira mensal",
+            "valores": {"valor_servicos": "1500.00", "iss_retido": 2}
+        },
+        "tomador": {
+            "razao_social": "Cliente NFSe Teste LTDA",
+            "cpf_cnpj": "00.987.654/3210-00",
+            "email": "cliente@teste.com",
+            "telefone": "62999990000",
+            "endereco": {
+                "logradouro": "Rua Central",
+                "numero": "100",
+                "bairro": "Centro",
+                "codigo_municipio": "5208707",
+                "uf": "GO",
+                "cep": "74000000"
+            }
+        },
+        "wsdl_url": "https://exemplo.prefeitura.gov.br/nfse?wsdl",
+        "service_url": "https://exemplo.prefeitura.gov.br/nfse.asmx"
+      }'
+```
+
+O retorno contém o XML gerado pelo serviço municipal. Caso já existam valores padrão no `.env`, os campos `wsdl_url` e `service_url` podem ser omitidos.
+
+## Estrutura de pastas relevante
+
+- `bpo_app/main.py`: aplicação FastAPI com autenticação por token, rotas de cadastro, importação de extratos e relatórios.
+- `bpo_app/models.py`: modelos do SQLAlchemy prontos para uso com SQLite ou PostgreSQL.
+- `bpo_app/frontend/`: arquivos HTML, CSS e JavaScript da interface amigável para o cliente.
+- `docker-compose.yml` e `Dockerfile`: containerização pronta para desenvolvimento.
+
+> A aplicação legado de monitoramento do eCAC continua disponível abaixo para referência.
+
 # Monitoramento do eCAC
 
 Este repositório contém uma ferramenta CLI em Python para monitorar periodicamente o eCAC para escritórios de contabilidade. Ela autentica usando o certificado digital de cada contribuinte (empresa ou pessoa física) ou, opcionalmente, apenas a procuração eletrônica do contador, consulta uma API proprietária e registra novos eventos em um banco SQLite, disparando alertas via webhook.

--- a/bpo_app/auth.py
+++ b/bpo_app/auth.py
@@ -1,0 +1,93 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+import bcrypt
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from .database import get_db
+from .models import User, UserRole
+from .schemas import CurrentUser
+
+if getattr(bcrypt, "__about__", None) is None and hasattr(bcrypt, "__version__"):
+    class _About:  # pragma: no cover - compatibility shim
+        __version__ = bcrypt.__version__  # type: ignore[attr-defined]
+
+    bcrypt.__about__ = _About()  # type: ignore[attr-defined]
+
+SECRET_KEY = "super-secret-placeholder"
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 12
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+def set_secret_key(value: str) -> None:
+    global SECRET_KEY
+    if value:
+        SECRET_KEY = value
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    if "sub" in to_encode:
+        to_encode["sub"] = str(to_encode["sub"])
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)
+) -> CurrentUser:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id_raw = payload.get("sub")
+        if user_id_raw is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token inválido")
+        try:
+            user_id = int(user_id_raw)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token inválido") from exc
+        if user_id is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token inválido")
+    except jwt.PyJWTError as exc:  # type: ignore[attr-defined]
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Token inválido"
+        ) from exc
+
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuário não encontrado")
+
+    return CurrentUser(
+        id=user.id,
+        full_name=user.full_name,
+        email=user.email,
+        role=user.role,
+        company_id=user.company_id,
+    )
+
+
+def require_role(*roles: UserRole):
+    def role_checker(current_user: CurrentUser = Depends(get_current_user)) -> CurrentUser:
+        if roles and current_user.role not in roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Você não tem permissão para esta ação.",
+            )
+        return current_user
+
+    return role_checker

--- a/bpo_app/classifier.py
+++ b/bpo_app/classifier.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from sqlalchemy.orm import Session
+
+from .models import Category, Transaction
+
+
+def classify_transaction(db: Session, transaction: Transaction) -> None:
+    if transaction.category_id:
+        return
+
+    categories: Iterable[Category] = (
+        db.query(Category)
+        .filter(Category.company_id == transaction.company_id)
+        .order_by(Category.name.asc())
+        .all()
+    )
+    description = (transaction.description or "").lower()
+    for category in categories:
+        if not category.keywords:
+            continue
+        keywords = [keyword.strip().lower() for keyword in category.keywords.split(",") if keyword.strip()]
+        if any(keyword in description for keyword in keywords):
+            transaction.category_id = category.id
+            transaction.auto_classified = True
+            break
+
+
+def ensure_default_categories(db: Session, company_id: int) -> None:
+    existing = db.query(Category).filter(Category.company_id == company_id).count()
+    if existing:
+        return
+
+    defaults = [
+        ("Vendas", "recebimento, pix, venda, deposito"),
+        ("Serviços", "mensalidade, honorário"),
+        ("Folha de Pagamento", "salario, holerite, folha"),
+        ("Impostos", "taxa, imposto, guiapgto, darf"),
+        ("Custos Fixos", "aluguel, energia, telefone, internet"),
+        ("Custos Variáveis", "fornecedor, compra, estoque"),
+        ("Outros", "transferencia, ajuste"),
+    ]
+    for name, keywords in defaults:
+        category = Category(company_id=company_id, name=name, keywords=keywords)
+        db.add(category)
+    db.commit()

--- a/bpo_app/database.py
+++ b/bpo_app/database.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine, make_url
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+from .settings import get_settings
+
+engine: Optional[Engine] = None
+SessionLocal: Optional[sessionmaker] = None
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+def init_engine(database_url: Optional[str] = None) -> Engine:
+    global engine, SessionLocal
+
+    settings = get_settings()
+    url = database_url or settings.database_url
+    parsed_url = make_url(url)
+
+    connect_args = {"check_same_thread": False} if parsed_url.drivername.startswith("sqlite") else {}
+
+    if parsed_url.drivername.startswith("sqlite") and parsed_url.database not in {None, "", ":memory:"}:
+        db_path = Path(parsed_url.database)
+        if not db_path.is_absolute():
+            db_path = Path.cwd() / db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if engine is not None:
+        engine.dispose()
+
+    engine = create_engine(url, connect_args=connect_args, future=True, pool_pre_ping=True)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    return engine
+
+
+def get_sessionmaker() -> sessionmaker:
+    global SessionLocal
+    if SessionLocal is None:
+        init_engine()
+    assert SessionLocal is not None
+    return SessionLocal
+
+
+def get_db():
+    session_factory = get_sessionmaker()
+    db: Session = session_factory()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+init_engine()
+
+
+__all__ = ["Base", "engine", "init_engine", "get_sessionmaker", "get_db", "SessionLocal"]

--- a/bpo_app/frontend/index.html
+++ b/bpo_app/frontend/index.html
@@ -1,0 +1,617 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BPO Financeiro Simples</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/app/styles.css" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A//www.w3.org/2000/svg'%20viewBox%3D'0%200%2064%2064'%3E%3Cdefs%3E%3ClinearGradient%20id%3D'grad'%20x1%3D'0%25'%20y1%3D'0%25'%20x2%3D'100%25'%20y2%3D'100%25'%3E%3Cstop%20offset%3D'0%25'%20style%3D'stop-color%3A%231f7a8c'%20/%3E%3Cstop%20offset%3D'100%25'%20style%3D'stop-color%3A%233cb7a0'%20/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect%20width%3D'64'%20height%3D'64'%20rx%3D'14'%20fill%3D'url(%23grad)'/%3E%3Ctext%20x%3D'50%25'%20y%3D'50%25'%20dominant-baseline%3D'central'%20text-anchor%3D'middle'%20font-size%3D'30'%20fill%3D'white'%20font-family%3D'Inter%2C%20Arial%2C%20sans-serif'%3EB%3C/text%3E%3C/svg%3E"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="topbar">
+        <div class="brand">
+          <span class="brand-icon">B</span>
+          <div class="brand-text">
+            <h1>BPO Financeiro Simples</h1>
+            <p>Visão clara do caixa para empresas que querem foco no negócio.</p>
+          </div>
+        </div>
+        <div class="top-actions hidden" id="top-actions">
+          <button id="open-config" class="ghost-button hidden" title="Abrir configurações">
+            <span>Configurações</span>
+          </button>
+          <button id="quick-export" class="ghost-button" title="Baixar relatório">
+            <span>Exportar</span>
+          </button>
+          <button id="logout" class="ghost-button">Sair</button>
+        </div>
+      </header>
+
+      <main class="main-content">
+        <section id="login-section" class="panel login-panel">
+          <div class="panel-body">
+            <h2>Entre para enxergar seus números</h2>
+            <p class="panel-description">
+              Use seu e-mail e senha enviados pelo contador para acessar o painel da sua empresa.
+            </p>
+            <form id="login-form" class="form">
+              <label for="email">E-mail</label>
+              <input type="email" id="email" name="email" placeholder="voce@suaempresa.com" required />
+
+              <label for="password">Senha</label>
+              <input
+                type="password"
+                id="password"
+                name="password"
+                placeholder="••••••"
+                autocomplete="current-password"
+                required
+              />
+
+              <button type="submit" class="primary-button">Entrar</button>
+              <p id="login-error" class="feedback"></p>
+            </form>
+          </div>
+          <div class="panel-aside">
+            <h3>O que você encontra aqui?</h3>
+            <ul>
+              <li>Resumo direto de entradas, saídas e resultado.</li>
+              <li>Gráficos com evolução do caixa mês a mês.</li>
+              <li>Lista de contas a pagar e receber com datas.</li>
+              <li>Exportação em PDF ou Excel para compartilhar.</li>
+            </ul>
+            <p class="panel-note">Tudo em linguagem simples, sem jargões contábeis.</p>
+          </div>
+        </section>
+
+        <section id="dashboard" class="dashboard hidden">
+          <div class="dashboard-grid">
+            <div class="panel stretch">
+              <div class="panel-header">
+                <div>
+                  <h2 id="welcome"></h2>
+                  <p id="period" class="muted"></p>
+                </div>
+                <div class="selector-group">
+                  <div class="company-selector hidden" id="company-selector">
+                    <label for="company-picker">Empresa</label>
+                    <select id="company-picker"></select>
+                  </div>
+                  <div class="period-selector" role="group" aria-label="Período do relatório">
+                    <button class="chip active" data-range="90">90 dias</button>
+                    <button class="chip" data-range="30">30 dias</button>
+                    <button class="chip" data-range="180">6 meses</button>
+                    <button class="chip" data-range="365">12 meses</button>
+                  </div>
+                </div>
+              </div>
+              <div class="highlight-grid" id="highlights"></div>
+            </div>
+
+            <div class="panel chart-panel">
+              <div class="panel-header">
+                <h3>Fluxo de Caixa no período</h3>
+                <p class="muted">Acompanhe como o saldo evoluiu mês a mês.</p>
+              </div>
+              <canvas id="cashflow-chart" height="220"></canvas>
+              <div class="table-wrapper">
+                <table id="cashflow-table">
+                  <thead>
+                    <tr>
+                      <th>Mês</th>
+                      <th>Entradas</th>
+                      <th>Saídas</th>
+                      <th>Saldo acumulado</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </div>
+            </div>
+
+            <div class="panel dre-panel">
+              <div class="panel-header">
+                <h3>Resultado resumido</h3>
+                <p class="muted">Veja se o período fechou no azul e onde concentrar atenção.</p>
+              </div>
+              <p id="dre-message" class="dre-message"></p>
+              <ul id="dre-values" class="dre-list"></ul>
+              <div class="download-card">
+                <label for="export-format">Exportar relatório:</label>
+                <select id="export-format">
+                  <option value="xlsx">Excel</option>
+                  <option value="pdf">PDF</option>
+                </select>
+                <button id="export-report" class="secondary-button">Baixar</button>
+              </div>
+            </div>
+
+            <div class="panel list-panel">
+              <div class="panel-header">
+                <h3>Contas a receber</h3>
+                <p class="muted">Valores esperados para entrar no caixa.</p>
+              </div>
+              <ul id="receivables-list" class="status-list"></ul>
+            </div>
+
+            <div class="panel list-panel">
+              <div class="panel-header">
+                <h3>Contas a pagar</h3>
+                <p class="muted">Acompanhe os compromissos que precisam ser pagos.</p>
+              </div>
+              <ul id="payables-list" class="status-list"></ul>
+            </div>
+
+            <div class="panel goals-panel">
+              <div class="panel-header">
+                <h3>Metas financeiras</h3>
+                <p class="muted">Veja se os objetivos estão evoluindo conforme o planejado.</p>
+              </div>
+              <div class="goal-metrics">
+                <div class="metric-card">
+                  <span class="metric-label">Metas ativas</span>
+                  <span id="goal-metric-active" class="metric-value">0</span>
+                </div>
+                <div class="metric-card">
+                  <span class="metric-label">Concluídas</span>
+                  <span id="goal-metric-achieved" class="metric-value positive">0</span>
+                </div>
+                <div class="metric-card">
+                  <span class="metric-label">Precisam de atenção</span>
+                  <span id="goal-metric-missed" class="metric-value warning">0</span>
+                </div>
+                <div class="metric-card">
+                  <span class="metric-label">Próximo prazo</span>
+                  <span id="goal-metric-next" class="metric-value">-</span>
+                </div>
+              </div>
+              <div id="goal-summary" class="goal-summary"></div>
+            </div>
+
+            <div class="panel tasks-panel">
+              <div class="panel-header">
+                <h3>Checklist financeiro</h3>
+                <p class="muted">Pendências e ações combinadas com o escritório.</p>
+              </div>
+              <div class="task-metrics">
+                <div class="metric-card">
+                  <span class="metric-label">Pendências</span>
+                  <span id="task-metric-pending" class="metric-value">0</span>
+                </div>
+                <div class="metric-card">
+                  <span class="metric-label">Em andamento</span>
+                  <span id="task-metric-in-progress" class="metric-value">0</span>
+                </div>
+                <div class="metric-card">
+                  <span class="metric-label">Concluídas</span>
+                  <span id="task-metric-done" class="metric-value positive">0</span>
+                </div>
+                <div class="metric-card">
+                  <span class="metric-label">Atrasadas</span>
+                  <span id="task-metric-overdue" class="metric-value warning">0</span>
+                </div>
+                <div class="metric-card">
+                  <span class="metric-label">Para hoje</span>
+                  <span id="task-metric-today" class="metric-value">0</span>
+                </div>
+              </div>
+              <ul id="task-summary-list" class="status-list"></ul>
+              <p id="task-summary-empty" class="muted small"></p>
+            </div>
+
+            <div class="panel contact-panel">
+              <div class="panel-header">
+                <h3>Converse com o contador</h3>
+                <p class="muted">Conte com o escritório para tirar dúvidas ou alinhar próximos passos.</p>
+              </div>
+              <div class="contact-grid">
+                <div>
+                  <span class="contact-label">E-mail</span>
+                  <span class="contact-value">atendimento@bpo.local</span>
+                </div>
+                <div>
+                  <span class="contact-label">WhatsApp</span>
+                  <span class="contact-value">(11) 90000-0000</span>
+                </div>
+                <div>
+                  <span class="contact-label">Central de ajuda</span>
+                  <span class="contact-value">bpo.local/ajuda</span>
+                </div>
+              </div>
+              <p class="contact-tip">
+                Sempre que precisar de um novo relatório ou quiser discutir resultados, envie uma mensagem pelo canal que preferir.
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <p>Feito para deixar o financeiro leve, transparente e conectado ao seu contador.</p>
+      </footer>
+    </div>
+
+    <div class="config-layer hidden" id="config-layer" aria-hidden="true">
+      <div class="config-container" role="dialog" aria-modal="true" aria-labelledby="config-title">
+        <div class="config-header">
+          <div>
+            <h2 id="config-title">Centro de Configurações</h2>
+            <p class="muted">Gerencie cadastros, lançamentos e importações do BPO.</p>
+          </div>
+          <button id="close-config" class="ghost-button">Fechar</button>
+        </div>
+        <div class="config-focus" id="config-focus">
+          <label for="config-company-focus">Empresa em foco</label>
+          <select id="config-company-focus"></select>
+        </div>
+        <div class="config-body">
+          <nav class="config-menu" id="config-menu">
+            <button class="active" data-tab="overview">Visão geral</button>
+            <button data-tab="companies">Empresas</button>
+            <button data-tab="users">Usuários</button>
+            <button data-tab="accounts">Contas bancárias</button>
+            <button data-tab="categories">Categorias</button>
+            <button data-tab="transactions">Lançamentos</button>
+            <button data-tab="imports">Importações</button>
+            <button data-tab="goals">Metas financeiras</button>
+            <button data-tab="tasks">Checklist</button>
+          </nav>
+          <div class="config-panels">
+            <section class="config-panel active" data-panel="overview">
+              <div class="config-panel-header">
+                <h3>Resumo do escritório</h3>
+                <p class="muted">Acompanhe rapidamente como está a base de cadastros.</p>
+              </div>
+              <div class="config-stats">
+                <article class="config-stat">
+                  <span class="config-stat-value" id="overview-companies-count">0</span>
+                  <span class="config-stat-label">Empresas ativas</span>
+                </article>
+                <article class="config-stat">
+                  <span class="config-stat-value" id="overview-users-count">0</span>
+                  <span class="config-stat-label">Usuários cadastrados</span>
+                </article>
+                <article class="config-stat">
+                  <span class="config-stat-value" id="overview-accounts-count">0</span>
+                  <span class="config-stat-label">Contas bancárias</span>
+                </article>
+                <article class="config-stat">
+                  <span class="config-stat-value" id="overview-categories-count">0</span>
+                  <span class="config-stat-label">Categorias criadas</span>
+                </article>
+                <article class="config-stat">
+                  <span class="config-stat-value" id="overview-goals-count">0</span>
+                  <span class="config-stat-label">Metas ativas</span>
+                </article>
+                <article class="config-stat">
+                  <span class="config-stat-value" id="overview-tasks-count">0</span>
+                  <span class="config-stat-label">Tarefas abertas</span>
+                </article>
+              </div>
+              <div class="config-hints">
+                <div class="hint-card">
+                  <h4>Como usar</h4>
+                  <p>Escolha uma empresa para visualizar contas, categorias, lançamentos e importar extratos.</p>
+                </div>
+                <div class="hint-card">
+                  <h4>Dica rápida</h4>
+                  <p>Mantenha pelo menos uma categoria de recebimentos e uma de pagamentos para melhorar os relatórios.</p>
+                </div>
+              </div>
+            </section>
+
+            <section class="config-panel" data-panel="companies">
+              <div class="config-panel-header">
+                <h3>Empresas</h3>
+                <p class="muted">Cadastre novos clientes e mantenha seus dados atualizados.</p>
+              </div>
+              <div class="config-columns">
+                <div class="config-column">
+                  <ul id="config-company-list" class="config-list"></ul>
+                </div>
+                <form id="config-company-form" class="config-form">
+                  <h4 id="config-company-form-title">Nova empresa</h4>
+                  <label>Nome da empresa
+                    <input type="text" id="config-company-name" name="name" required />
+                  </label>
+                  <label>Nome fantasia
+                    <input type="text" id="config-company-trade" name="trade_name" />
+                  </label>
+                  <label>CNPJ ou CPF
+                    <input type="text" id="config-company-document" name="document" />
+                  </label>
+                  <label>Notas internas
+                    <textarea id="config-company-notes" name="notes" rows="3"></textarea>
+                  </label>
+                  <div class="form-actions">
+                    <button type="submit" class="primary-button">Salvar</button>
+                    <button type="button" id="config-company-cancel" class="ghost-button small hidden">Cancelar edição</button>
+                  </div>
+                  <p id="config-company-feedback" class="config-feedback"></p>
+                </form>
+              </div>
+            </section>
+
+            <section class="config-panel" data-panel="users">
+              <div class="config-panel-header">
+                <h3>Usuários</h3>
+                <p class="muted">Convide sua equipe e clientes para usar o painel.</p>
+              </div>
+              <div class="config-columns">
+                <div class="config-column">
+                  <ul id="config-user-list" class="config-list"></ul>
+                </div>
+                <form id="config-user-form" class="config-form">
+                  <h4 id="config-user-form-title">Novo usuário</h4>
+                  <label>Nome completo
+                    <input type="text" id="config-user-name" required />
+                  </label>
+                  <label>E-mail
+                    <input type="email" id="config-user-email" required />
+                  </label>
+                  <label>Perfil de acesso
+                    <select id="config-user-role" required>
+                      <option value="admin">Administrador</option>
+                      <option value="staff">Equipe interna</option>
+                      <option value="client">Cliente</option>
+                    </select>
+                  </label>
+                  <label>Empresa vinculada
+                    <select id="config-user-company"></select>
+                  </label>
+                  <label>Senha (mínimo 6 caracteres)
+                    <input
+                      type="password"
+                      id="config-user-password"
+                      minlength="6"
+                      autocomplete="new-password"
+                    />
+                  </label>
+                  <label>
+                    <input type="checkbox" id="config-user-active" checked /> Usuário ativo
+                  </label>
+                  <div class="form-actions">
+                    <button type="submit" class="primary-button">Salvar usuário</button>
+                    <button type="button" id="config-user-cancel" class="ghost-button small hidden">Cancelar edição</button>
+                  </div>
+                  <p id="config-user-feedback" class="config-feedback"></p>
+                </form>
+              </div>
+            </section>
+
+            <section class="config-panel" data-panel="accounts">
+              <div class="config-panel-header">
+                <h3>Contas bancárias</h3>
+                <p class="muted">Cadastre contas para separar entradas e saídas de cada empresa.</p>
+              </div>
+              <div class="config-columns">
+                <div class="config-column">
+                  <ul id="config-account-list" class="config-list"></ul>
+                </div>
+                <form id="config-account-form" class="config-form">
+                  <h4>Criar conta bancária</h4>
+                  <label>Nome da conta
+                    <input type="text" id="config-account-name" required />
+                  </label>
+                  <label>Banco
+                    <input type="text" id="config-account-bank" />
+                  </label>
+                  <label>Número da conta
+                    <input type="text" id="config-account-number" />
+                  </label>
+                  <label>Saldo inicial
+                    <input type="number" step="0.01" id="config-account-balance" value="0" />
+                  </label>
+                  <div class="form-actions">
+                    <button type="submit" class="primary-button">Adicionar conta</button>
+                  </div>
+                  <p id="config-account-feedback" class="config-feedback"></p>
+                </form>
+              </div>
+            </section>
+
+            <section class="config-panel" data-panel="categories">
+              <div class="config-panel-header">
+                <h3>Categorias</h3>
+                <p class="muted">Organize entradas e saídas com palavras-chave para classificação automática.</p>
+              </div>
+              <div class="config-columns">
+                <div class="config-column">
+                  <ul id="config-category-list" class="config-list"></ul>
+                </div>
+                <form id="config-category-form" class="config-form">
+                  <h4>Nova categoria</h4>
+                  <label>Nome da categoria
+                    <input type="text" id="config-category-name" required />
+                  </label>
+                  <label>Palavras-chave (separe por vírgula)
+                    <input type="text" id="config-category-keywords" placeholder="mensalidade, assinatura" />
+                  </label>
+                  <label>Cor opcional
+                    <input type="color" id="config-category-color" value="#1f7a8c" />
+                  </label>
+                  <div class="form-actions">
+                    <button type="submit" class="primary-button">Salvar categoria</button>
+                  </div>
+                  <p id="config-category-feedback" class="config-feedback"></p>
+                </form>
+              </div>
+            </section>
+
+            <section class="config-panel" data-panel="transactions">
+              <div class="config-panel-header">
+                <h3>Lançamentos manuais</h3>
+                <p class="muted">Registre entradas e saídas que não vieram do extrato.</p>
+              </div>
+              <div class="config-columns">
+                <div class="config-column">
+                  <table class="config-table">
+                    <thead>
+                      <tr>
+                        <th>Data</th>
+                        <th>Descrição</th>
+                        <th>Tipo</th>
+                        <th>Valor</th>
+                        <th>Categoria</th>
+                      </tr>
+                    </thead>
+                    <tbody id="config-transaction-list"></tbody>
+                  </table>
+                </div>
+                <form id="config-transaction-form" class="config-form">
+                  <h4>Novo lançamento</h4>
+                  <label>Data
+                    <input type="date" id="config-transaction-date" required />
+                  </label>
+                  <label>Descrição
+                    <input type="text" id="config-transaction-description" required />
+                  </label>
+                  <label>Valor
+                    <input type="number" step="0.01" id="config-transaction-amount" required />
+                  </label>
+                  <label>Tipo
+                    <select id="config-transaction-type" required>
+                      <option value="inflow">Entrada</option>
+                      <option value="outflow">Saída</option>
+                    </select>
+                  </label>
+                  <label>Conta bancária
+                    <select id="config-transaction-account"></select>
+                  </label>
+                  <label>Categoria
+                    <select id="config-transaction-category"></select>
+                  </label>
+                  <label>Observações
+                    <textarea id="config-transaction-notes" rows="2"></textarea>
+                  </label>
+                  <div class="form-actions">
+                    <button type="submit" class="primary-button">Registrar</button>
+                  </div>
+                  <p id="config-transaction-feedback" class="config-feedback"></p>
+                </form>
+              </div>
+            </section>
+
+            <section class="config-panel" data-panel="imports">
+              <div class="config-panel-header">
+                <h3>Importação de extratos</h3>
+                <p class="muted">Carregue arquivos CSV, Excel ou OFX para acelerar o registro de lançamentos.</p>
+              </div>
+              <form id="config-import-form" class="config-form single">
+                <label>Selecione o arquivo do banco
+                  <input type="file" id="config-import-file" accept=".csv,.xls,.xlsx,.ofx" required />
+                </label>
+                <p class="muted small">Certifique-se de que a coluna de data esteja no formato dia/mês/ano ou ano-mês-dia.</p>
+                <div class="form-actions">
+                  <button type="submit" class="primary-button">Importar extrato</button>
+                </div>
+                <p id="config-import-feedback" class="config-feedback"></p>
+              </form>
+            </section>
+
+            <section class="config-panel" data-panel="goals">
+              <div class="config-panel-header">
+                <h3>Metas financeiras</h3>
+                <p class="muted">Defina objetivos de entrada ou de controle de gastos para cada empresa.</p>
+              </div>
+              <div class="config-columns">
+                <div class="config-column">
+                  <ul id="config-goal-list" class="config-list"></ul>
+                </div>
+                <form id="config-goal-form" class="config-form">
+                  <h4 id="config-goal-form-title">Nova meta</h4>
+                  <label>Nome da meta
+                    <input type="text" id="config-goal-name" required />
+                  </label>
+                  <label>Descrição
+                    <textarea id="config-goal-description" rows="3"></textarea>
+                  </label>
+                  <label>Tipo de objetivo
+                    <select id="config-goal-direction">
+                      <option value="inflow">Aumentar entradas</option>
+                      <option value="outflow">Controlar saídas</option>
+                    </select>
+                  </label>
+                  <label>Valor desejado
+                    <input type="number" step="0.01" id="config-goal-target" required />
+                  </label>
+                  <label>Início da meta
+                    <input type="date" id="config-goal-start" required />
+                  </label>
+                  <label>Fim da meta
+                    <input type="date" id="config-goal-end" required />
+                  </label>
+                  <label class="inline-checkbox">
+                    <input type="checkbox" id="config-goal-archived" /> Arquivar meta concluída
+                  </label>
+                  <div class="form-actions">
+                    <button type="submit" class="primary-button">Salvar meta</button>
+                    <button type="button" id="config-goal-cancel" class="ghost-button small hidden">Cancelar edição</button>
+                  </div>
+                  <p id="config-goal-feedback" class="config-feedback"></p>
+                </form>
+              </div>
+              <div class="config-insights">
+                <h4>Progresso das metas</h4>
+                <div id="config-goal-progress" class="goal-progress-grid"></div>
+              </div>
+            </section>
+
+            <section class="config-panel" data-panel="tasks">
+              <div class="config-panel-header">
+                <h3>Checklist financeiro</h3>
+                <p class="muted">Organize pendências e combine responsáveis com o cliente.</p>
+              </div>
+              <div class="config-columns">
+                <div class="config-column">
+                  <ul id="config-task-list" class="config-list"></ul>
+                </div>
+                <form id="config-task-form" class="config-form">
+                  <h4 id="config-task-form-title">Nova tarefa</h4>
+                  <label>Título
+                    <input type="text" id="config-task-title" required />
+                  </label>
+                  <label>Detalhes
+                    <textarea id="config-task-description" rows="3"></textarea>
+                  </label>
+                  <label>Responsável
+                    <select id="config-task-owner"></select>
+                  </label>
+                  <label>Prazo
+                    <input type="date" id="config-task-due" />
+                  </label>
+                  <label>Status
+                    <select id="config-task-status">
+                      <option value="open">Aberta</option>
+                      <option value="in_progress">Em andamento</option>
+                      <option value="done">Concluída</option>
+                    </select>
+                  </label>
+                  <div class="form-actions">
+                    <button type="submit" class="primary-button">Salvar tarefa</button>
+                    <button type="button" id="config-task-cancel" class="ghost-button small hidden">Cancelar edição</button>
+                  </div>
+                  <p id="config-task-feedback" class="config-feedback"></p>
+                </form>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="/app/main.js"></script>
+  </body>
+</html>

--- a/bpo_app/frontend/main.js
+++ b/bpo_app/frontend/main.js
@@ -1,0 +1,2345 @@
+const API_BASE = '';
+let token = null;
+let currentUser = null;
+let selectedCompany = null;
+let periodPreset = '90';
+let cashflowChart = null;
+let cachedCompanies = [];
+let cachedUsers = [];
+let cachedAccounts = [];
+let cachedCategories = [];
+let cachedTransactions = [];
+let cachedGoals = [];
+let cachedTasks = [];
+let cachedGoalSummary = null;
+let cachedTaskSummary = null;
+let configCompanyId = null;
+let currentConfigTab = 'overview';
+let editingCompanyId = null;
+let editingUserId = null;
+let editingGoalId = null;
+let editingTaskId = null;
+
+const ROLE_LABELS = {
+  admin: 'Administrador',
+  staff: 'Equipe interna',
+  client: 'Cliente'
+};
+
+const GOAL_DIRECTION_LABELS = {
+  inflow: 'Entradas',
+  outflow: 'Saídas'
+};
+
+const GOAL_STATUS_LABELS = {
+  in_progress: 'Em andamento',
+  achieved: 'Concluída',
+  missed: 'Ajustar meta'
+};
+
+const TASK_STATUS_LABELS = {
+  open: 'Aberta',
+  in_progress: 'Em andamento',
+  done: 'Concluída'
+};
+
+const PERIOD_PRESETS = {
+  '30': {
+    label: 'Últimos 30 dias',
+    compute() {
+      const end = new Date();
+      const start = new Date();
+      start.setDate(end.getDate() - 29);
+      return { start, end };
+    }
+  },
+  '90': {
+    label: 'Últimos 90 dias',
+    compute() {
+      const end = new Date();
+      const start = new Date();
+      start.setDate(end.getDate() - 89);
+      return { start, end };
+    }
+  },
+  '180': {
+    label: 'Últimos 6 meses',
+    compute() {
+      const end = new Date();
+      const start = new Date();
+      start.setMonth(end.getMonth() - 5);
+      start.setDate(1);
+      return { start, end };
+    }
+  },
+  '365': {
+    label: 'Últimos 12 meses',
+    compute() {
+      const end = new Date();
+      const start = new Date();
+      start.setFullYear(end.getFullYear() - 1);
+      start.setDate(end.getDate() + 1);
+      return { start, end };
+    }
+  }
+};
+
+async function apiRequest(path, options = {}) {
+  const config = { ...options };
+  config.headers = config.headers ? { ...config.headers } : {};
+  if (token) {
+    config.headers['Authorization'] = `Bearer ${token}`;
+  }
+  const isForm = config.body instanceof FormData;
+  if (!isForm && !config.headers['Content-Type'] && config.method && config.method !== 'GET') {
+    config.headers['Content-Type'] = 'application/json';
+  }
+  const response = await fetch(`${API_BASE}${path}`, config);
+  if (!response.ok) {
+    if (response.status === 401) {
+      handleLogout();
+    }
+    let detail = 'Algo deu errado.';
+    try {
+      const data = await response.json();
+      detail = data.detail || data.message || detail;
+    } catch (error) {
+      // ignore JSON parse errors
+    }
+    throw new Error(detail);
+  }
+  if (response.status === 204) {
+    return null;
+  }
+  const contentType = response.headers.get('content-type');
+  if (contentType && contentType.includes('application/json')) {
+    return response.json();
+  }
+  return response;
+}
+
+function formatCurrency(value) {
+  return Number(value || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+function formatDate(isoDate) {
+  const date = new Date(isoDate);
+  return date.toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' });
+}
+
+function setFeedback(elementId, message, isError = false) {
+  const element = document.getElementById(elementId);
+  if (!element) {
+    return;
+  }
+  element.textContent = message;
+  element.classList.toggle('success', Boolean(message) && !isError);
+  element.classList.toggle('error', Boolean(message) && isError);
+}
+
+function clearFeedback(elementId) {
+  setFeedback(elementId, '');
+}
+
+function normalizeStringValue(value) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const cleaned = String(value).trim();
+  return cleaned ? cleaned : null;
+}
+
+function isAdminOrStaff() {
+  return currentUser && (currentUser.role === 'admin' || currentUser.role === 'staff');
+}
+
+function getActiveCompanyId() {
+  if (!currentUser) {
+    return null;
+  }
+  if (currentUser.role === 'client') {
+    return currentUser.company_id || null;
+  }
+  return configCompanyId || selectedCompany || null;
+}
+
+function toggleCompanyDependentForms(disabled) {
+  const ids = [
+    'config-account-form',
+    'config-category-form',
+    'config-transaction-form',
+    'config-import-form',
+    'config-goal-form',
+    'config-task-form'
+  ];
+  ids.forEach((formId) => {
+    const form = document.getElementById(formId);
+    if (!form) {
+      return;
+    }
+    form.classList.toggle('disabled', disabled);
+    Array.from(form.querySelectorAll('input, select, textarea, button')).forEach((element) => {
+      element.disabled = disabled;
+    });
+  });
+}
+
+function updateMetricValue(id, value) {
+  const element = document.getElementById(id);
+  if (element) {
+    element.textContent = value;
+  }
+}
+
+function updateGoalMetrics(summary) {
+  const total = summary?.total ?? 0;
+  const archived = summary?.archived ?? 0;
+  const active = Math.max(total - archived, 0);
+  updateMetricValue('goal-metric-active', String(active));
+  updateMetricValue('goal-metric-achieved', String(summary?.achieved ?? 0));
+  updateMetricValue('goal-metric-missed', String(summary?.missed ?? 0));
+  const nextElement = document.getElementById('goal-metric-next');
+  if (nextElement) {
+    if (summary?.next_deadline) {
+      const nextDate = summary.next_deadline;
+      const today = new Date();
+      const isoToday = today.toISOString().slice(0, 10);
+      if (nextDate === isoToday) {
+        nextElement.textContent = 'Hoje';
+      } else {
+        nextElement.textContent = formatDate(nextDate);
+      }
+    } else {
+      nextElement.textContent = '-';
+    }
+  }
+}
+
+function updateTaskMetrics(summary) {
+  const open = summary?.open ?? 0;
+  const inProgress = summary?.in_progress ?? 0;
+  const pendingTotal = open + inProgress;
+  updateMetricValue('task-metric-pending', String(pendingTotal));
+  updateMetricValue('task-metric-in-progress', String(inProgress));
+  updateMetricValue('task-metric-done', String(summary?.done ?? 0));
+  updateMetricValue('task-metric-overdue', String(summary?.overdue ?? 0));
+  updateMetricValue('task-metric-today', String(summary?.due_today ?? 0));
+}
+
+function populateTransactionAccountOptions() {
+  const select = document.getElementById('config-transaction-account');
+  if (!select) {
+    return;
+  }
+  select.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Sem conta específica';
+  select.appendChild(placeholder);
+  cachedAccounts.forEach((account) => {
+    const option = document.createElement('option');
+    option.value = account.id;
+    option.textContent = account.name;
+    select.appendChild(option);
+  });
+}
+
+function populateTransactionCategoryOptions() {
+  const select = document.getElementById('config-transaction-category');
+  if (!select) {
+    return;
+  }
+  select.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Sem categoria';
+  select.appendChild(placeholder);
+  cachedCategories.forEach((category) => {
+    const option = document.createElement('option');
+    option.value = category.id;
+    option.textContent = category.name;
+    select.appendChild(option);
+  });
+}
+
+function populateUserCompanySelect() {
+  const select = document.getElementById('config-user-company');
+  if (!select) {
+    return;
+  }
+  select.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Sem vínculo (somente equipe)';
+  select.appendChild(placeholder);
+  cachedCompanies.forEach((company) => {
+    const option = document.createElement('option');
+    option.value = company.id;
+    option.textContent = company.name;
+    select.appendChild(option);
+  });
+  if (configCompanyId) {
+    select.value = String(configCompanyId);
+  }
+}
+
+function populateTaskAssigneeSelect() {
+  const select = document.getElementById('config-task-owner');
+  if (!select) {
+    return;
+  }
+  select.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Sem responsável definido';
+  select.appendChild(placeholder);
+
+  let options = [];
+  if (isAdminOrStaff()) {
+    options = cachedUsers.filter((user) => user.is_active !== false);
+  } else if (currentUser) {
+    options = [currentUser];
+  }
+
+  options.forEach((user) => {
+    const option = document.createElement('option');
+    option.value = user.id;
+    const companyName = user.company_id
+      ? cachedCompanies.find((company) => company.id === user.company_id)?.name
+      : null;
+    option.textContent = companyName ? `${user.full_name} · ${companyName}` : user.full_name;
+    select.appendChild(option);
+  });
+}
+
+function populateConfigFocusSelect() {
+  const wrapper = document.getElementById('config-focus');
+  const select = document.getElementById('config-company-focus');
+  if (!wrapper || !select) {
+    return;
+  }
+  const hasCompanies = cachedCompanies.length > 0;
+  wrapper.classList.toggle('hidden', currentUser?.role === 'client');
+  select.innerHTML = '';
+  if (!hasCompanies) {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = 'Cadastre uma empresa para começar';
+    select.appendChild(option);
+    select.disabled = true;
+    toggleCompanyDependentForms(true);
+    return;
+  }
+  select.disabled = currentUser?.role === 'client';
+  cachedCompanies.forEach((company) => {
+    const option = document.createElement('option');
+    option.value = company.id;
+    option.textContent = company.name;
+    select.appendChild(option);
+  });
+  const fallbackCompany =
+    configCompanyId && cachedCompanies.some((company) => company.id === Number(configCompanyId))
+      ? Number(configCompanyId)
+      : currentUser?.role === 'client'
+        ? currentUser.company_id
+        : cachedCompanies[0]?.id;
+  configCompanyId = fallbackCompany ? Number(fallbackCompany) : null;
+  if (configCompanyId) {
+    select.value = String(configCompanyId);
+  } else {
+    select.value = '';
+  }
+  toggleCompanyDependentForms(!configCompanyId);
+  populateUserCompanySelect();
+}
+
+function updateConfigCounts() {
+  const setCount = (id, value) => {
+    const element = document.getElementById(id);
+    if (element) {
+      element.textContent = String(value ?? 0);
+    }
+  };
+  setCount('overview-companies-count', cachedCompanies.length);
+  setCount('overview-users-count', cachedUsers.length);
+  setCount('overview-accounts-count', cachedAccounts.length);
+  setCount('overview-categories-count', cachedCategories.length);
+  const activeGoals = cachedGoals.filter((item) => !item.goal.archived).length;
+  const pendingTasks = cachedTasks.filter((task) => task.status !== 'done').length;
+  setCount('overview-goals-count', activeGoals);
+  setCount('overview-tasks-count', pendingTasks);
+}
+
+function updateConfigMenuVisibility() {
+  const usersButton = document.querySelector('#config-menu button[data-tab="users"]');
+  const usersPanel = document.querySelector('.config-panel[data-panel="users"]');
+  const showUsers = isAdminOrStaff();
+  if (usersButton) {
+    usersButton.classList.toggle('hidden', !showUsers);
+    if (!showUsers && currentConfigTab === 'users') {
+      currentConfigTab = 'overview';
+    }
+  }
+  if (usersPanel) {
+    usersPanel.classList.toggle('hidden', !showUsers);
+  }
+}
+
+function updateRoleBasedUI() {
+  const configButton = document.getElementById('open-config');
+  const showConfig = isAdminOrStaff();
+  if (configButton) {
+    configButton.classList.toggle('hidden', !showConfig);
+  }
+  if (currentUser?.role === 'client') {
+    configCompanyId = currentUser.company_id || null;
+  }
+  updateConfigMenuVisibility();
+  populateConfigFocusSelect();
+}
+function toggleView(isLogged) {
+  document.getElementById('login-section').classList.toggle('hidden', isLogged);
+  document.getElementById('dashboard').classList.toggle('hidden', !isLogged);
+  document.getElementById('top-actions').classList.toggle('hidden', !isLogged);
+}
+
+function updatePeriodButtons(rangeKey) {
+  document.querySelectorAll('.period-selector .chip').forEach((chip) => {
+    chip.classList.toggle('active', chip.dataset.range === rangeKey);
+  });
+}
+
+function computePeriodRange(rangeKey) {
+  const preset = PERIOD_PRESETS[rangeKey] || PERIOD_PRESETS['90'];
+  const { start, end } = preset.compute();
+  const normalizedStart = new Date(Date.UTC(start.getFullYear(), start.getMonth(), start.getDate()));
+  const normalizedEnd = new Date(Date.UTC(end.getFullYear(), end.getMonth(), end.getDate()));
+  return {
+    start: normalizedStart.toISOString().split('T')[0],
+    end: normalizedEnd.toISOString().split('T')[0]
+  };
+}
+
+async function fetchCompanies() {
+  const companies = await apiRequest('/companies');
+  cachedCompanies = companies;
+  populateConfigFocusSelect();
+  return companies;
+}
+
+async function loadHighlights() {
+  const highlights = await apiRequest('/dashboard/overview');
+  const container = document.getElementById('highlights');
+  container.innerHTML = '';
+  if (!highlights.length) {
+    container.innerHTML = '<p class="muted">Cadastre empresas e lançamentos para liberar os destaques.</p>';
+    return;
+  }
+  highlights.forEach((highlight) => {
+    const card = document.createElement('div');
+    card.className = 'highlight-card';
+    const numericValue = Number(highlight.value.replace(/[^0-9,-]/g, '').replace(',', '.'));
+    if (!Number.isNaN(numericValue)) {
+      card.classList.add(numericValue >= 0 ? 'positive' : 'negative');
+    }
+    card.innerHTML = `
+      <span class="title">${highlight.title}</span>
+      <span class="value">${highlight.value}</span>
+      <span class="description">${highlight.description}</span>
+    `;
+    container.appendChild(card);
+  });
+}
+
+function renderOutstanding(listId, items, type) {
+  const list = document.getElementById(listId);
+  list.innerHTML = '';
+  if (!items.length) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-state';
+    empty.textContent = type === 'receivables'
+      ? 'Sem entradas previstas no período selecionado.'
+      : 'Sem pagamentos pendentes no período selecionado.';
+    list.appendChild(empty);
+    return;
+  }
+  items.slice(0, 6).forEach((item) => {
+    const li = document.createElement('li');
+    li.className = `status-item ${type === 'receivables' ? 'positive' : 'negative'}`;
+    li.innerHTML = `
+      <div class="status-meta">
+        <span>${item.description}</span>
+        <span class="status-date">Para ${formatDate(item.due_date)}</span>
+      </div>
+      <div class="status-info">
+        <span class="status-chip">${type === 'receivables' ? 'Entrada' : 'Saída'}</span>
+        <span class="status-amount">${formatCurrency(item.amount)}</span>
+      </div>
+    `;
+    list.appendChild(li);
+  });
+}
+
+function renderGoalSummary(summary) {
+  const container = document.getElementById('goal-summary');
+  if (!container) {
+    return;
+  }
+  container.innerHTML = '';
+  updateGoalMetrics(summary);
+  if (!summary) {
+    const empty = document.createElement('p');
+    empty.className = 'muted small';
+    empty.textContent = 'Cadastre metas para acompanhar objetivos financeiros aqui.';
+    container.appendChild(empty);
+    return;
+  }
+  const upcoming = summary.upcoming || [];
+  if (!upcoming.length) {
+    const message = document.createElement('p');
+    message.className = 'muted small';
+    if (summary.total === 0) {
+      message.textContent = 'Cadastre metas para acompanhar objetivos financeiros aqui.';
+    } else {
+      message.textContent = 'Todas as metas estão concluídas ou arquivadas no momento.';
+    }
+    container.appendChild(message);
+    return;
+  }
+  upcoming.forEach((item) => {
+    const card = document.createElement('article');
+    card.className = `goal-summary-card status-${item.status}`;
+    const header = document.createElement('div');
+    header.className = 'goal-summary-header';
+    const title = document.createElement('strong');
+    title.textContent = item.goal.name;
+    header.appendChild(title);
+    const direction = document.createElement('span');
+    direction.className = 'goal-summary-direction';
+    direction.textContent = GOAL_DIRECTION_LABELS[item.goal.direction] || item.goal.direction;
+    header.appendChild(direction);
+    card.appendChild(header);
+
+    const statusLabel = document.createElement('span');
+    statusLabel.className = `status-pill goal-summary-status status-${item.status}`;
+    statusLabel.textContent = GOAL_STATUS_LABELS[item.status] || item.status;
+    card.appendChild(statusLabel);
+
+    const progressText = document.createElement('div');
+    progressText.className = 'goal-summary-values';
+    progressText.textContent = `${formatCurrency(item.actual_amount)} de ${formatCurrency(item.goal.target_amount)}`;
+    card.appendChild(progressText);
+
+    const bar = document.createElement('div');
+    bar.className = 'goal-progress-bar';
+    const fill = document.createElement('div');
+    fill.style.width = `${Math.min(item.progress_percentage, 100)}%`;
+    bar.appendChild(fill);
+    card.appendChild(bar);
+
+    const message = document.createElement('p');
+    message.className = 'muted small';
+    message.textContent = item.message;
+    card.appendChild(message);
+
+    container.appendChild(card);
+  });
+
+  const totalUpcoming = upcoming.length;
+  const activeGoals = Math.max((summary.total ?? 0) - (summary.archived ?? 0), 0);
+  if (activeGoals > totalUpcoming) {
+    const hint = document.createElement('p');
+    hint.className = 'muted small';
+    hint.textContent = `+${activeGoals - totalUpcoming} metas disponíveis no centro de configurações.`;
+    container.appendChild(hint);
+  }
+}
+
+function renderTaskSummary(summary) {
+  const list = document.getElementById('task-summary-list');
+  const empty = document.getElementById('task-summary-empty');
+  if (!list || !empty) {
+    return;
+  }
+  list.innerHTML = '';
+  updateTaskMetrics(summary);
+  const tasks = summary?.spotlight ?? [];
+  const pendingTotal = (summary?.open ?? 0) + (summary?.in_progress ?? 0);
+  if (!tasks.length) {
+    if ((summary?.total ?? 0) === 0) {
+      empty.textContent = 'Cadastre tarefas para controlar entregas combinadas com o escritório.';
+    } else {
+      empty.textContent = 'Checklist em dia! Não há tarefas pendentes.';
+    }
+    return;
+  }
+  empty.textContent = '';
+  tasks.slice(0, 4).forEach((task) => {
+    const li = document.createElement('li');
+    li.className = 'task-summary-item';
+
+    const title = document.createElement('div');
+    title.className = 'task-summary-title';
+    const strong = document.createElement('strong');
+    strong.textContent = task.title;
+    title.appendChild(strong);
+    if (task.description) {
+      const desc = document.createElement('p');
+      desc.className = 'muted small';
+      desc.textContent = task.description;
+      title.appendChild(desc);
+    }
+    li.appendChild(title);
+
+    const meta = document.createElement('div');
+    meta.className = 'task-summary-meta';
+    const statusChip = document.createElement('span');
+    statusChip.className = `task-summary-chip status-${task.status}`;
+    statusChip.textContent = TASK_STATUS_LABELS[task.status] || task.status;
+    meta.appendChild(statusChip);
+
+    const dueInfo = document.createElement('span');
+    dueInfo.className = 'task-summary-date';
+    dueInfo.textContent = task.due_date ? `Até ${formatDate(task.due_date)}` : 'Sem prazo definido';
+    meta.appendChild(dueInfo);
+
+    const owner = document.createElement('span');
+    owner.className = 'task-summary-owner';
+    owner.textContent = task.assigned_to ? task.assigned_to.full_name : 'Sem responsável';
+    meta.appendChild(owner);
+
+    li.appendChild(meta);
+    list.appendChild(li);
+  });
+
+  if (pendingTotal > 4) {
+    const more = document.createElement('li');
+    more.className = 'task-summary-more muted small';
+    more.textContent = `+${pendingTotal - 4} tarefas aguardando atenção.`;
+    list.appendChild(more);
+  }
+}
+
+async function loadGoalSummary() {
+  const container = document.getElementById('goal-summary');
+  if (!container || !currentUser) {
+    return;
+  }
+  let companyId = selectedCompany || currentUser.company_id || configCompanyId;
+  if (isAdminOrStaff()) {
+    if (!companyId && cachedCompanies.length) {
+      companyId = cachedCompanies[0].id;
+    }
+  }
+  if (!companyId) {
+    cachedGoalSummary = null;
+    updateGoalMetrics(null);
+    container.innerHTML = '<p class="muted small">Cadastre uma empresa e metas financeiras para visualizar aqui.</p>';
+    return;
+  }
+  try {
+    const summary = await apiRequest(`/financial-goals/summary?company_id=${companyId}`);
+    cachedGoalSummary = summary;
+    renderGoalSummary(summary);
+  } catch (error) {
+    cachedGoalSummary = null;
+    updateGoalMetrics(null);
+    container.innerHTML = `<p class="muted small">${error.message}</p>`;
+  }
+}
+
+async function loadTaskSummary() {
+  const list = document.getElementById('task-summary-list');
+  const empty = document.getElementById('task-summary-empty');
+  if (!list || !empty || !currentUser) {
+    return;
+  }
+  let companyId = selectedCompany || currentUser.company_id || configCompanyId;
+  if (isAdminOrStaff()) {
+    if (!companyId && cachedCompanies.length) {
+      companyId = cachedCompanies[0].id;
+    }
+  }
+  if (!companyId) {
+    cachedTaskSummary = null;
+    updateTaskMetrics(null);
+    renderTaskSummary(null);
+    return;
+  }
+  try {
+    const summary = await apiRequest(`/tasks/summary?company_id=${companyId}`);
+    cachedTaskSummary = summary;
+    renderTaskSummary(summary);
+  } catch (error) {
+    cachedTaskSummary = null;
+    updateTaskMetrics(null);
+    empty.textContent = error.message;
+  }
+}
+
+function renderCashflowTable(entries) {
+  const tbody = document.querySelector('#cashflow-table tbody');
+  tbody.innerHTML = '';
+  entries.forEach((entry) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${entry.label}</td>
+      <td>${formatCurrency(entry.inflow)}</td>
+      <td>${formatCurrency(entry.outflow)}</td>
+      <td>${formatCurrency(entry.balance)}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+function renderCashflowChart(entries) {
+  const ctx = document.getElementById('cashflow-chart').getContext('2d');
+  const labels = entries.map((entry) => entry.label);
+  const inflow = entries.map((entry) => entry.inflow);
+  const outflow = entries.map((entry) => entry.outflow);
+  const balance = entries.map((entry) => entry.balance);
+
+  if (cashflowChart) {
+    cashflowChart.data.labels = labels;
+    cashflowChart.data.datasets[0].data = inflow;
+    cashflowChart.data.datasets[1].data = outflow;
+    cashflowChart.data.datasets[2].data = balance;
+    cashflowChart.update();
+    return;
+  }
+
+  cashflowChart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Entradas',
+          data: inflow,
+          borderColor: '#3cb7a0',
+          backgroundColor: 'rgba(60, 183, 160, 0.25)',
+          tension: 0.35,
+          fill: true,
+          borderWidth: 3
+        },
+        {
+          label: 'Saídas',
+          data: outflow,
+          borderColor: '#d64045',
+          backgroundColor: 'rgba(214, 64, 69, 0.12)',
+          tension: 0.35,
+          fill: true,
+          borderWidth: 3
+        },
+        {
+          label: 'Saldo acumulado',
+          data: balance,
+          borderColor: '#1f7a8c',
+          backgroundColor: 'rgba(31, 122, 140, 0.18)',
+          tension: 0.25,
+          fill: false,
+          borderDash: [6, 6],
+          borderWidth: 3
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        y: {
+          ticks: {
+            callback: (value) => formatCurrency(value)
+          }
+        }
+      },
+      plugins: {
+        legend: {
+          display: true
+        },
+        tooltip: {
+          callbacks: {
+            label(context) {
+              return `${context.dataset.label}: ${formatCurrency(context.parsed.y)}`;
+            }
+          }
+        }
+      }
+    }
+  });
+}
+
+async function loadFinancialReport() {
+  if (!currentUser) {
+    return;
+  }
+  const { start, end } = computePeriodRange(periodPreset);
+
+  let companyId = selectedCompany;
+  if (!companyId && currentUser.company_id) {
+    companyId = currentUser.company_id;
+  }
+  if (!companyId) {
+    const companies = await apiRequest('/companies');
+    if (companies.length) {
+      companyId = companies[0].id;
+      selectedCompany = companyId;
+    } else {
+      document.getElementById('period').textContent = 'Cadastre uma empresa para liberar os relatórios.';
+      document.getElementById('dre-message').textContent = '';
+      document.getElementById('dre-values').innerHTML = '';
+      document.querySelector('#cashflow-table tbody').innerHTML = '';
+      document.getElementById('receivables-list').innerHTML = '';
+      document.getElementById('payables-list').innerHTML = '';
+      return;
+    }
+  }
+
+  const report = await apiRequest(
+    `/reports/financial-health?company_id=${companyId}&start_date=${start}&end_date=${end}`
+  );
+
+  document.getElementById('period').textContent = report.period;
+  document.getElementById('dre-message').textContent = report.dre.message;
+
+  const dreValues = document.getElementById('dre-values');
+  dreValues.innerHTML = '';
+  const dreLabels = [
+    { key: 'revenue', label: 'Entradas' },
+    { key: 'expenses', label: 'Saídas' },
+    { key: 'result', label: 'Resultado' }
+  ];
+  dreLabels.forEach(({ key, label }) => {
+    const li = document.createElement('li');
+    li.textContent = `${label}: ${formatCurrency(report.dre[key])}`;
+    dreValues.appendChild(li);
+  });
+
+  renderCashflowTable(report.cash_flow);
+  renderCashflowChart(report.cash_flow);
+  renderOutstanding('receivables-list', report.receivables, 'receivables');
+  renderOutstanding('payables-list', report.payables, 'payables');
+}
+
+async function populateCompanies() {
+  const selectContainer = document.getElementById('company-selector');
+  const select = document.getElementById('company-picker');
+  if (!currentUser) {
+    selectContainer.classList.add('hidden');
+    return;
+  }
+
+  const companies = await fetchCompanies();
+  if (!companies.length) {
+    selectContainer.classList.add('hidden');
+    selectedCompany = null;
+    return;
+  }
+
+  if (currentUser.role === 'client') {
+    selectContainer.classList.add('hidden');
+    selectedCompany = currentUser.company_id;
+    configCompanyId = currentUser.company_id;
+    return;
+  }
+
+  if (!selectedCompany || !companies.some((company) => company.id === Number(selectedCompany))) {
+    selectedCompany = companies[0].id;
+  }
+
+  selectContainer.classList.toggle('hidden', companies.length <= 1);
+  select.innerHTML = '';
+  companies.forEach((company) => {
+    const option = document.createElement('option');
+    option.value = company.id;
+    option.textContent = company.name;
+    if (Number(selectedCompany) === company.id) {
+      option.selected = true;
+    }
+    select.appendChild(option);
+  });
+
+  if (isAdminOrStaff() && !configCompanyId) {
+    configCompanyId = Number(selectedCompany);
+    populateConfigFocusSelect();
+  }
+}
+
+function renderCompanyList(companies) {
+  const list = document.getElementById('config-company-list');
+  if (!list) {
+    return;
+  }
+  list.innerHTML = '';
+  if (!companies.length) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-state';
+    empty.textContent = 'Cadastre a primeira empresa para liberar os demais recursos.';
+    list.appendChild(empty);
+    return;
+  }
+  companies.forEach((company) => {
+    const li = document.createElement('li');
+    const meta = document.createElement('div');
+    meta.className = 'item-meta';
+    const title = document.createElement('strong');
+    title.textContent = company.name;
+    meta.appendChild(title);
+    if (company.trade_name) {
+      const trade = document.createElement('span');
+      trade.className = 'muted';
+      trade.textContent = company.trade_name;
+      meta.appendChild(trade);
+    }
+    if (company.document) {
+      const documentInfo = document.createElement('span');
+      documentInfo.className = 'muted small';
+      documentInfo.textContent = company.document;
+      meta.appendChild(documentInfo);
+    }
+    li.appendChild(meta);
+
+    if (isAdminOrStaff()) {
+      const actions = document.createElement('div');
+      actions.className = 'item-actions';
+      const editButton = document.createElement('button');
+      editButton.className = 'inline';
+      editButton.dataset.action = 'edit';
+      editButton.dataset.id = company.id;
+      editButton.textContent = 'Editar';
+      actions.appendChild(editButton);
+      if (currentUser?.role === 'admin') {
+        const deleteButton = document.createElement('button');
+        deleteButton.className = 'inline';
+        deleteButton.dataset.action = 'delete';
+        deleteButton.dataset.id = company.id;
+        deleteButton.textContent = 'Remover';
+        actions.appendChild(deleteButton);
+      }
+      li.appendChild(actions);
+    }
+
+    list.appendChild(li);
+  });
+}
+
+function resetCompanyForm() {
+  const form = document.getElementById('config-company-form');
+  if (!form) {
+    return;
+  }
+  form.reset();
+  editingCompanyId = null;
+  const title = document.getElementById('config-company-form-title');
+  if (title) {
+    title.textContent = 'Nova empresa';
+  }
+  const cancelButton = document.getElementById('config-company-cancel');
+  if (cancelButton) {
+    cancelButton.classList.add('hidden');
+  }
+  clearFeedback('config-company-feedback');
+}
+
+function startCompanyEdit(companyId) {
+  const company = cachedCompanies.find((item) => item.id === Number(companyId));
+  if (!company) {
+    return;
+  }
+  editingCompanyId = company.id;
+  const title = document.getElementById('config-company-form-title');
+  if (title) {
+    title.textContent = 'Editar empresa';
+  }
+  const cancelButton = document.getElementById('config-company-cancel');
+  if (cancelButton) {
+    cancelButton.classList.remove('hidden');
+  }
+  document.getElementById('config-company-name').value = company.name || '';
+  document.getElementById('config-company-trade').value = company.trade_name || '';
+  document.getElementById('config-company-document').value = company.document || '';
+  document.getElementById('config-company-notes').value = company.notes || '';
+}
+
+async function refreshCompaniesSection() {
+  const companies = await fetchCompanies();
+  renderCompanyList(companies);
+  updateConfigCounts();
+}
+
+async function handleCompanySubmit(event) {
+  event.preventDefault();
+  const nameInput = document.getElementById('config-company-name');
+  const payload = {
+    name: nameInput.value.trim(),
+    trade_name: normalizeStringValue(document.getElementById('config-company-trade').value),
+    document: normalizeStringValue(document.getElementById('config-company-document').value),
+    notes: normalizeStringValue(document.getElementById('config-company-notes').value)
+  };
+  if (!payload.name) {
+    setFeedback('config-company-feedback', 'Informe o nome da empresa.', true);
+    return;
+  }
+  const isEditing = Boolean(editingCompanyId);
+  const url = isEditing ? `/companies/${editingCompanyId}` : '/companies';
+  const method = isEditing ? 'PUT' : 'POST';
+  try {
+    const response = await apiRequest(url, {
+      method,
+      body: JSON.stringify(payload)
+    });
+    setFeedback(
+      'config-company-feedback',
+      isEditing ? 'Empresa atualizada com sucesso!' : 'Empresa cadastrada com sucesso!',
+      false
+    );
+    if (!isEditing && response?.id) {
+      configCompanyId = response.id;
+    }
+    await refreshCompaniesSection();
+    await populateCompanies();
+    await refreshAccountsSection();
+    await refreshCategoriesSection();
+    await refreshTransactionsSection();
+    resetCompanyForm();
+  } catch (error) {
+    setFeedback('config-company-feedback', error.message, true);
+  }
+}
+
+async function handleCompanyListClick(event) {
+  const button = event.target.closest('button[data-action]');
+  if (!button) {
+    return;
+  }
+  const companyId = Number(button.dataset.id);
+  if (button.dataset.action === 'edit') {
+    startCompanyEdit(companyId);
+    return;
+  }
+  if (button.dataset.action === 'delete') {
+    const company = cachedCompanies.find((item) => item.id === companyId);
+    if (!company) {
+      return;
+    }
+    const confirmed = window.confirm(
+      `Tem certeza de que deseja remover a empresa "${company.name}"? Esta ação não pode ser desfeita.`
+    );
+    if (!confirmed) {
+      return;
+    }
+    try {
+      await apiRequest(`/companies/${companyId}`, { method: 'DELETE' });
+      setFeedback('config-company-feedback', 'Empresa removida.', false);
+      if (configCompanyId === companyId) {
+        configCompanyId = null;
+      }
+      await refreshCompaniesSection();
+      await populateCompanies();
+      await refreshAccountsSection();
+      await refreshCategoriesSection();
+      await refreshTransactionsSection();
+    } catch (error) {
+      setFeedback('config-company-feedback', error.message, true);
+    }
+  }
+}
+
+function renderUserList(users) {
+  const list = document.getElementById('config-user-list');
+  if (!list) {
+    return;
+  }
+  list.innerHTML = '';
+  if (!isAdminOrStaff()) {
+    const info = document.createElement('li');
+    info.className = 'empty-state';
+    info.textContent = 'Somente o escritório pode gerenciar usuários.';
+    list.appendChild(info);
+    return;
+  }
+  if (!users.length) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-state';
+    empty.textContent = 'Nenhum usuário cadastrado ainda.';
+    list.appendChild(empty);
+    return;
+  }
+  users.forEach((user) => {
+    const li = document.createElement('li');
+    const meta = document.createElement('div');
+    meta.className = 'item-meta';
+    const title = document.createElement('strong');
+    title.textContent = user.full_name;
+    meta.appendChild(title);
+    const email = document.createElement('span');
+    email.className = 'muted';
+    email.textContent = user.email;
+    meta.appendChild(email);
+    const companyName = user.company_id
+      ? cachedCompanies.find((company) => company.id === user.company_id)?.name
+      : null;
+    const badge = document.createElement('span');
+    badge.className = 'muted small';
+    badge.textContent = `${ROLE_LABELS[user.role] || user.role}${companyName ? ` · ${companyName}` : ''}`;
+    if (user.is_active === false) {
+      badge.textContent += ' · Inativo';
+    }
+    meta.appendChild(badge);
+    li.appendChild(meta);
+
+    const actions = document.createElement('div');
+    actions.className = 'item-actions';
+    const editButton = document.createElement('button');
+    editButton.className = 'inline';
+    editButton.dataset.action = 'edit';
+    editButton.dataset.id = user.id;
+    editButton.textContent = 'Editar';
+    actions.appendChild(editButton);
+    li.appendChild(actions);
+
+    list.appendChild(li);
+  });
+}
+
+function resetUserForm() {
+  const form = document.getElementById('config-user-form');
+  if (!form) {
+    return;
+  }
+  form.reset();
+  editingUserId = null;
+  document.getElementById('config-user-active').checked = true;
+  const title = document.getElementById('config-user-form-title');
+  if (title) {
+    title.textContent = 'Novo usuário';
+  }
+  const cancelButton = document.getElementById('config-user-cancel');
+  if (cancelButton) {
+    cancelButton.classList.add('hidden');
+  }
+  clearFeedback('config-user-feedback');
+  populateUserCompanySelect();
+}
+
+function startUserEdit(userId) {
+  const user = cachedUsers.find((item) => item.id === Number(userId));
+  if (!user) {
+    return;
+  }
+  editingUserId = user.id;
+  const title = document.getElementById('config-user-form-title');
+  if (title) {
+    title.textContent = 'Editar usuário';
+  }
+  const cancelButton = document.getElementById('config-user-cancel');
+  if (cancelButton) {
+    cancelButton.classList.remove('hidden');
+  }
+  document.getElementById('config-user-name').value = user.full_name;
+  document.getElementById('config-user-email').value = user.email;
+  document.getElementById('config-user-role').value = user.role;
+  populateUserCompanySelect();
+  const companySelect = document.getElementById('config-user-company');
+  if (companySelect) {
+    companySelect.value = user.company_id ? String(user.company_id) : '';
+  }
+  document.getElementById('config-user-password').value = '';
+  document.getElementById('config-user-active').checked = user.is_active !== false;
+}
+
+async function refreshUsersSection() {
+  if (!isAdminOrStaff()) {
+    cachedUsers = [];
+    renderUserList([]);
+    populateTaskAssigneeSelect();
+    updateConfigCounts();
+    return;
+  }
+  const users = await apiRequest('/users');
+  cachedUsers = users;
+  renderUserList(users);
+  populateTaskAssigneeSelect();
+  updateConfigCounts();
+}
+
+async function handleUserSubmit(event) {
+  event.preventDefault();
+  if (!isAdminOrStaff()) {
+    setFeedback('config-user-feedback', 'Somente o escritório pode gerenciar usuários.', true);
+    return;
+  }
+  const fullName = document.getElementById('config-user-name').value.trim();
+  const email = document.getElementById('config-user-email').value.trim().toLowerCase();
+  const role = document.getElementById('config-user-role').value;
+  const companyValue = document.getElementById('config-user-company').value;
+  const password = document.getElementById('config-user-password').value.trim();
+  const isActive = document.getElementById('config-user-active').checked;
+
+  if (!fullName || !email) {
+    setFeedback('config-user-feedback', 'Informe nome completo e e-mail.', true);
+    return;
+  }
+  if (role === 'client' && !companyValue) {
+    setFeedback('config-user-feedback', 'Clientes precisam estar vinculados a uma empresa.', true);
+    return;
+  }
+  if (!editingUserId && password.length < 6) {
+    setFeedback('config-user-feedback', 'Defina uma senha com pelo menos 6 caracteres.', true);
+    return;
+  }
+
+  const payload = {
+    full_name: fullName,
+    email,
+    role,
+    company_id: companyValue ? Number(companyValue) : null,
+    is_active: isActive
+  };
+  if (!editingUserId || password) {
+    payload.password = password;
+  }
+  const url = editingUserId ? `/users/${editingUserId}` : '/users';
+  const method = editingUserId ? 'PUT' : 'POST';
+  try {
+    await apiRequest(url, {
+      method,
+      body: JSON.stringify(payload)
+    });
+    setFeedback('config-user-feedback', 'Usuário salvo com sucesso!', false);
+    await refreshUsersSection();
+    resetUserForm();
+  } catch (error) {
+    setFeedback('config-user-feedback', error.message, true);
+  }
+}
+
+function handleUserListClick(event) {
+  const button = event.target.closest('button[data-action]');
+  if (!button) {
+    return;
+  }
+  if (button.dataset.action === 'edit') {
+    startUserEdit(button.dataset.id);
+  }
+}
+
+function renderAccountList(accounts) {
+  const list = document.getElementById('config-account-list');
+  if (!list) {
+    return;
+  }
+  list.innerHTML = '';
+  if (!accounts.length) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-state';
+    empty.textContent = 'Nenhuma conta cadastrada para a empresa selecionada.';
+    list.appendChild(empty);
+    return;
+  }
+  accounts.forEach((account) => {
+    const li = document.createElement('li');
+    const meta = document.createElement('div');
+    meta.className = 'item-meta';
+    const title = document.createElement('strong');
+    title.textContent = account.name;
+    meta.appendChild(title);
+    const details = document.createElement('span');
+    details.className = 'muted small';
+    const parts = [];
+    if (account.bank_name) {
+      parts.push(account.bank_name);
+    }
+    if (account.account_number) {
+      parts.push(`Conta ${account.account_number}`);
+    }
+    parts.push(`Saldo inicial: ${formatCurrency(account.initial_balance)}`);
+    details.textContent = parts.join(' · ');
+    meta.appendChild(details);
+    li.appendChild(meta);
+    list.appendChild(li);
+  });
+}
+
+async function refreshAccountsSection() {
+  const companyId = getActiveCompanyId();
+  if (!companyId) {
+    cachedAccounts = [];
+    renderAccountList([]);
+    populateTransactionAccountOptions();
+    updateConfigCounts();
+    toggleCompanyDependentForms(true);
+    return;
+  }
+  toggleCompanyDependentForms(false);
+  const accounts = await apiRequest(`/bank-accounts?company_id=${companyId}`);
+  cachedAccounts = accounts;
+  renderAccountList(accounts);
+  populateTransactionAccountOptions();
+  updateConfigCounts();
+}
+
+async function handleAccountSubmit(event) {
+  event.preventDefault();
+  const companyId = getActiveCompanyId();
+  if (!companyId) {
+    setFeedback('config-account-feedback', 'Selecione uma empresa para cadastrar a conta.', true);
+    return;
+  }
+  const name = document.getElementById('config-account-name').value.trim();
+  if (!name) {
+    setFeedback('config-account-feedback', 'Informe o nome da conta bancária.', true);
+    return;
+  }
+  const payload = {
+    company_id: companyId,
+    name,
+    bank_name: normalizeStringValue(document.getElementById('config-account-bank').value),
+    account_number: normalizeStringValue(document.getElementById('config-account-number').value),
+    initial_balance: Number(document.getElementById('config-account-balance').value || 0)
+  };
+  try {
+    await apiRequest('/bank-accounts', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+    setFeedback('config-account-feedback', 'Conta cadastrada com sucesso!', false);
+    document.getElementById('config-account-form').reset();
+    document.getElementById('config-account-balance').value = '0';
+    await refreshAccountsSection();
+    await refreshTransactionsSection();
+    await loadFinancialReport();
+  } catch (error) {
+    setFeedback('config-account-feedback', error.message, true);
+  }
+}
+
+function renderCategoryList(categories) {
+  const list = document.getElementById('config-category-list');
+  if (!list) {
+    return;
+  }
+  list.innerHTML = '';
+  if (!categories.length) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-state';
+    empty.textContent = 'Crie categorias para organizar os lançamentos.';
+    list.appendChild(empty);
+    return;
+  }
+  categories.forEach((category) => {
+    const li = document.createElement('li');
+    const meta = document.createElement('div');
+    meta.className = 'item-meta';
+    const title = document.createElement('strong');
+    title.textContent = category.name;
+    meta.appendChild(title);
+    const info = document.createElement('span');
+    info.className = 'muted small';
+    info.textContent = category.keywords
+      ? `Palavras-chave: ${category.keywords}`
+      : 'Sem palavras-chave configuradas';
+    meta.appendChild(info);
+    li.appendChild(meta);
+    list.appendChild(li);
+  });
+}
+
+async function refreshCategoriesSection() {
+  const companyId = getActiveCompanyId();
+  if (!companyId) {
+    cachedCategories = [];
+    renderCategoryList([]);
+    populateTransactionCategoryOptions();
+    updateConfigCounts();
+    return;
+  }
+  const categories = await apiRequest(`/categories?company_id=${companyId}`);
+  cachedCategories = categories;
+  renderCategoryList(categories);
+  populateTransactionCategoryOptions();
+  updateConfigCounts();
+}
+
+async function handleCategorySubmit(event) {
+  event.preventDefault();
+  const companyId = getActiveCompanyId();
+  if (!companyId) {
+    setFeedback('config-category-feedback', 'Selecione uma empresa para salvar a categoria.', true);
+    return;
+  }
+  const name = document.getElementById('config-category-name').value.trim();
+  if (!name) {
+    setFeedback('config-category-feedback', 'Informe o nome da categoria.', true);
+    return;
+  }
+  const payload = {
+    company_id: companyId,
+    name,
+    keywords: normalizeStringValue(document.getElementById('config-category-keywords').value),
+    color: normalizeStringValue(document.getElementById('config-category-color').value)
+  };
+  try {
+    await apiRequest('/categories', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+    setFeedback('config-category-feedback', 'Categoria criada com sucesso!', false);
+    document.getElementById('config-category-form').reset();
+    document.getElementById('config-category-color').value = '#1f7a8c';
+    await refreshCategoriesSection();
+    await refreshTransactionsSection();
+  } catch (error) {
+    setFeedback('config-category-feedback', error.message, true);
+  }
+}
+
+function renderTransactionList(transactions) {
+  const tbody = document.getElementById('config-transaction-list');
+  if (!tbody) {
+    return;
+  }
+  tbody.innerHTML = '';
+  if (!transactions.length) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 5;
+    cell.className = 'muted';
+    cell.textContent = 'Sem lançamentos registrados no período selecionado.';
+    row.appendChild(cell);
+    tbody.appendChild(row);
+    return;
+  }
+  transactions.slice(0, 20).forEach((transaction) => {
+    const row = document.createElement('tr');
+    const categoryName = transaction.category_id
+      ? cachedCategories.find((category) => category.id === transaction.category_id)?.name
+      : null;
+    row.innerHTML = `
+      <td>${new Date(transaction.date).toLocaleDateString('pt-BR')}</td>
+      <td>${transaction.description}</td>
+      <td>${transaction.transaction_type === 'inflow' ? 'Entrada' : 'Saída'}</td>
+      <td>${formatCurrency(Number(transaction.amount))}</td>
+      <td>${categoryName || '-'}</td>
+    `;
+    tbody.appendChild(row);
+  });
+}
+
+async function refreshTransactionsSection() {
+  const companyId = getActiveCompanyId();
+  if (!companyId) {
+    cachedTransactions = [];
+    renderTransactionList([]);
+    return;
+  }
+  const { start, end } = computePeriodRange('180');
+  const transactions = await apiRequest(
+    `/transactions?company_id=${companyId}&start_date=${start}&end_date=${end}`
+  );
+  cachedTransactions = transactions;
+  renderTransactionList(transactions);
+}
+
+async function handleTransactionSubmit(event) {
+  event.preventDefault();
+  const companyId = getActiveCompanyId();
+  if (!companyId) {
+    setFeedback('config-transaction-feedback', 'Selecione uma empresa antes de registrar lançamentos.', true);
+    return;
+  }
+  const description = document.getElementById('config-transaction-description').value.trim();
+  const amountValue = Number(document.getElementById('config-transaction-amount').value);
+  if (!description || Number.isNaN(amountValue)) {
+    setFeedback('config-transaction-feedback', 'Informe a descrição e o valor do lançamento.', true);
+    return;
+  }
+  const payload = {
+    company_id: companyId,
+    date: document.getElementById('config-transaction-date').value,
+    description,
+    amount: amountValue,
+    transaction_type: document.getElementById('config-transaction-type').value,
+    bank_account_id: normalizeStringValue(document.getElementById('config-transaction-account').value),
+    category_id: normalizeStringValue(document.getElementById('config-transaction-category').value),
+    notes: normalizeStringValue(document.getElementById('config-transaction-notes').value)
+  };
+  if (!payload.date) {
+    setFeedback('config-transaction-feedback', 'Informe a data do lançamento.', true);
+    return;
+  }
+  if (payload.bank_account_id) {
+    payload.bank_account_id = Number(payload.bank_account_id);
+  }
+  if (payload.category_id) {
+    payload.category_id = Number(payload.category_id);
+  }
+  try {
+    await apiRequest('/transactions', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+    setFeedback('config-transaction-feedback', 'Lançamento registrado!', false);
+    const form = document.getElementById('config-transaction-form');
+    form.reset();
+    document.getElementById('config-transaction-type').value = 'inflow';
+    await refreshTransactionsSection();
+    await loadFinancialReport();
+    await loadHighlights();
+  } catch (error) {
+    setFeedback('config-transaction-feedback', error.message, true);
+  }
+}
+
+async function handleImportSubmit(event) {
+  event.preventDefault();
+  const companyId = getActiveCompanyId();
+  if (!companyId) {
+    setFeedback('config-import-feedback', 'Selecione uma empresa para importar o extrato.', true);
+    return;
+  }
+  const fileInput = document.getElementById('config-import-file');
+  if (!fileInput.files || !fileInput.files.length) {
+    setFeedback('config-import-feedback', 'Escolha um arquivo CSV, Excel ou OFX.', true);
+    return;
+  }
+  const formData = new FormData();
+  formData.append('file', fileInput.files[0]);
+  try {
+    const summary = await apiRequest(`/transactions/import?company_id=${companyId}`, {
+      method: 'POST',
+      body: formData
+    });
+    setFeedback(
+      'config-import-feedback',
+      `Importação concluída: ${summary.imported} lançamentos adicionados.`,
+      false
+    );
+    fileInput.value = '';
+    await refreshTransactionsSection();
+    await loadFinancialReport();
+    await loadHighlights();
+  } catch (error) {
+    setFeedback('config-import-feedback', error.message, true);
+  }
+}
+
+function messageFromGoal(item) {
+  return item.message || '';
+}
+
+function renderGoalProgress(goals) {
+  const container = document.getElementById('config-goal-progress');
+  if (!container) {
+    return;
+  }
+  container.innerHTML = '';
+  if (!goals.length) {
+    const empty = document.createElement('p');
+    empty.className = 'muted';
+    empty.textContent = 'Cadastre metas para acompanhar o avanço das entradas e saídas.';
+    container.appendChild(empty);
+    return;
+  }
+  goals.forEach((item) => {
+    const card = document.createElement('article');
+    card.className = `goal-progress-card status-${item.status}`;
+    card.innerHTML = `
+      <header>
+        <strong>${item.goal.name}</strong>
+        <span>${GOAL_DIRECTION_LABELS[item.goal.direction] || item.goal.direction}</span>
+      </header>
+      <div class="goal-progress-values">
+        <span>${formatCurrency(item.actual_amount)}</span>
+        <span>de ${formatCurrency(item.goal.target_amount)}</span>
+      </div>
+      <div class="goal-progress-bar"><div style="width: ${Math.min(item.progress_percentage, 100)}%"></div></div>
+      <footer>
+        <span class="status-pill status-${item.status}">${GOAL_STATUS_LABELS[item.status] || item.status}</span>
+        <span class="muted small">${messageFromGoal(item)}</span>
+      </footer>
+    `;
+    container.appendChild(card);
+  });
+}
+
+function renderGoalList(goals) {
+  const list = document.getElementById('config-goal-list');
+  if (!list) {
+    return;
+  }
+  list.innerHTML = '';
+  if (!goals.length) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-state';
+    empty.textContent = 'Nenhuma meta cadastrada para a empresa selecionada.';
+    list.appendChild(empty);
+    return;
+  }
+  goals.forEach((item) => {
+    const { goal, status, progress_percentage } = item;
+    const li = document.createElement('li');
+    const meta = document.createElement('div');
+    meta.className = 'item-meta';
+
+    const title = document.createElement('strong');
+    title.textContent = goal.name;
+    meta.appendChild(title);
+
+    const period = document.createElement('span');
+    period.className = 'muted small';
+    period.textContent = `Período: ${formatDate(goal.period_start)} até ${formatDate(goal.period_end)}`;
+    meta.appendChild(period);
+
+    const details = document.createElement('span');
+    details.className = 'muted small';
+    details.textContent = `${GOAL_DIRECTION_LABELS[goal.direction] || goal.direction} · ${progress_percentage.toFixed(0)}%`;
+    meta.appendChild(details);
+
+    if (goal.archived) {
+      const archived = document.createElement('span');
+      archived.className = 'status-pill status-archived';
+      archived.textContent = 'Arquivada';
+      meta.appendChild(archived);
+    } else {
+      const statusPill = document.createElement('span');
+      statusPill.className = `status-pill status-${status}`;
+      statusPill.textContent = GOAL_STATUS_LABELS[status] || status;
+      meta.appendChild(statusPill);
+    }
+
+    li.appendChild(meta);
+
+    const actions = document.createElement('div');
+    actions.className = 'item-actions';
+    const editButton = document.createElement('button');
+    editButton.className = 'inline';
+    editButton.dataset.action = 'edit';
+    editButton.dataset.id = goal.id;
+    editButton.textContent = 'Editar';
+    actions.appendChild(editButton);
+
+    const deleteButton = document.createElement('button');
+    deleteButton.className = 'inline';
+    deleteButton.dataset.action = 'delete';
+    deleteButton.dataset.id = goal.id;
+    deleteButton.textContent = 'Remover';
+    actions.appendChild(deleteButton);
+
+    li.appendChild(actions);
+    list.appendChild(li);
+  });
+}
+
+function resetGoalForm() {
+  const form = document.getElementById('config-goal-form');
+  if (!form) {
+    return;
+  }
+  form.reset();
+  editingGoalId = null;
+  const title = document.getElementById('config-goal-form-title');
+  if (title) {
+    title.textContent = 'Nova meta';
+  }
+  document.getElementById('config-goal-direction').value = 'inflow';
+  document.getElementById('config-goal-archived').checked = false;
+  const cancelButton = document.getElementById('config-goal-cancel');
+  if (cancelButton) {
+    cancelButton.classList.add('hidden');
+  }
+  clearFeedback('config-goal-feedback');
+}
+
+function startGoalEdit(goalId) {
+  const goal = cachedGoals.find((item) => item.goal.id === Number(goalId));
+  if (!goal) {
+    return;
+  }
+  editingGoalId = goal.goal.id;
+  const title = document.getElementById('config-goal-form-title');
+  if (title) {
+    title.textContent = 'Editar meta';
+  }
+  const cancelButton = document.getElementById('config-goal-cancel');
+  if (cancelButton) {
+    cancelButton.classList.remove('hidden');
+  }
+  document.getElementById('config-goal-name').value = goal.goal.name;
+  document.getElementById('config-goal-description').value = goal.goal.description || '';
+  document.getElementById('config-goal-direction').value = goal.goal.direction;
+  document.getElementById('config-goal-target').value = goal.goal.target_amount;
+  document.getElementById('config-goal-start').value = goal.goal.period_start;
+  document.getElementById('config-goal-end').value = goal.goal.period_end;
+  document.getElementById('config-goal-archived').checked = Boolean(goal.goal.archived);
+}
+
+async function refreshGoalsSection() {
+  const companyId = getActiveCompanyId();
+  if (!companyId) {
+    cachedGoals = [];
+    renderGoalList([]);
+    renderGoalProgress([]);
+    updateConfigCounts();
+    return;
+  }
+  try {
+    const goals = await apiRequest(`/financial-goals?company_id=${companyId}`);
+    cachedGoals = goals;
+    renderGoalList(goals);
+    renderGoalProgress(goals);
+    updateConfigCounts();
+  } catch (error) {
+    setFeedback('config-goal-feedback', error.message, true);
+  }
+}
+
+async function handleGoalSubmit(event) {
+  event.preventDefault();
+  const companyId = getActiveCompanyId();
+  if (!companyId && !editingGoalId) {
+    setFeedback('config-goal-feedback', 'Escolha a empresa antes de salvar a meta.', true);
+    return;
+  }
+  const targetInput = document.getElementById('config-goal-target');
+  const targetAmount = Number(targetInput.value);
+  if (!Number.isFinite(targetAmount) || targetAmount <= 0) {
+    setFeedback('config-goal-feedback', 'Informe um valor de meta maior que zero.', true);
+    return;
+  }
+  const startValue = document.getElementById('config-goal-start').value;
+  const endValue = document.getElementById('config-goal-end').value;
+  if (startValue && endValue && new Date(endValue) < new Date(startValue)) {
+    setFeedback('config-goal-feedback', 'A data final deve ser posterior ou igual ao início da meta.', true);
+    return;
+  }
+
+  const payload = {
+    name: document.getElementById('config-goal-name').value.trim(),
+    description: normalizeStringValue(document.getElementById('config-goal-description').value),
+    direction: document.getElementById('config-goal-direction').value,
+    target_amount: targetAmount,
+    period_start: startValue,
+    period_end: endValue,
+    archived: document.getElementById('config-goal-archived').checked
+  };
+
+  const isEditing = Boolean(editingGoalId);
+  const url = isEditing ? `/financial-goals/${editingGoalId}` : '/financial-goals';
+  const method = isEditing ? 'PUT' : 'POST';
+  if (!isEditing) {
+    payload.company_id = companyId;
+  }
+  try {
+    await apiRequest(url, {
+      method,
+      body: JSON.stringify(payload)
+    });
+    setFeedback('config-goal-feedback', 'Meta salva com sucesso!', false);
+    await refreshGoalsSection();
+    await loadGoalSummary();
+    resetGoalForm();
+  } catch (error) {
+    setFeedback('config-goal-feedback', error.message, true);
+  }
+}
+
+async function handleGoalListClick(event) {
+  const button = event.target.closest('button[data-action]');
+  if (!button) {
+    return;
+  }
+  const goalId = button.dataset.id;
+  if (button.dataset.action === 'edit') {
+    startGoalEdit(goalId);
+    return;
+  }
+  if (button.dataset.action === 'delete') {
+    const confirmed = window.confirm('Deseja remover esta meta?');
+    if (!confirmed) {
+      return;
+    }
+    try {
+      await apiRequest(`/financial-goals/${goalId}`, { method: 'DELETE' });
+      await refreshGoalsSection();
+      await loadGoalSummary();
+      setFeedback('config-goal-feedback', 'Meta removida.', false);
+    } catch (error) {
+      setFeedback('config-goal-feedback', error.message, true);
+    }
+  }
+}
+
+function renderTaskList(tasks) {
+  const list = document.getElementById('config-task-list');
+  if (!list) {
+    return;
+  }
+  list.innerHTML = '';
+  if (!tasks.length) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-state';
+    empty.textContent = 'Nenhuma tarefa cadastrada para a empresa selecionada.';
+    list.appendChild(empty);
+    return;
+  }
+  tasks.forEach((task) => {
+    const li = document.createElement('li');
+    const meta = document.createElement('div');
+    meta.className = 'item-meta';
+    const title = document.createElement('strong');
+    title.textContent = task.title;
+    meta.appendChild(title);
+    if (task.description) {
+      const description = document.createElement('span');
+      description.className = 'muted';
+      description.textContent = task.description;
+      meta.appendChild(description);
+    }
+    const info = document.createElement('span');
+    info.className = 'muted small';
+    const due = task.due_date ? `Até ${formatDate(task.due_date)}` : 'Sem prazo definido';
+    const owner = task.assigned_to ? task.assigned_to.full_name : 'Sem responsável';
+    info.textContent = `${TASK_STATUS_LABELS[task.status] || task.status} · ${due} · ${owner}`;
+    meta.appendChild(info);
+    li.appendChild(meta);
+
+    const actions = document.createElement('div');
+    actions.className = 'item-actions';
+    const editButton = document.createElement('button');
+    editButton.className = 'inline';
+    editButton.dataset.action = 'edit';
+    editButton.dataset.id = task.id;
+    editButton.textContent = 'Editar';
+    actions.appendChild(editButton);
+
+    if (task.status !== 'done') {
+      const completeButton = document.createElement('button');
+      completeButton.className = 'inline';
+      completeButton.dataset.action = 'complete';
+      completeButton.dataset.id = task.id;
+      completeButton.textContent = 'Concluir';
+      actions.appendChild(completeButton);
+    }
+
+    const deleteButton = document.createElement('button');
+    deleteButton.className = 'inline';
+    deleteButton.dataset.action = 'delete';
+    deleteButton.dataset.id = task.id;
+    deleteButton.textContent = 'Remover';
+    actions.appendChild(deleteButton);
+
+    li.appendChild(actions);
+    list.appendChild(li);
+  });
+}
+
+function resetTaskForm() {
+  const form = document.getElementById('config-task-form');
+  if (!form) {
+    return;
+  }
+  form.reset();
+  editingTaskId = null;
+  const title = document.getElementById('config-task-form-title');
+  if (title) {
+    title.textContent = 'Nova tarefa';
+  }
+  const cancelButton = document.getElementById('config-task-cancel');
+  if (cancelButton) {
+    cancelButton.classList.add('hidden');
+  }
+  document.getElementById('config-task-status').value = 'open';
+  populateTaskAssigneeSelect();
+  clearFeedback('config-task-feedback');
+}
+
+function startTaskEdit(taskId) {
+  const task = cachedTasks.find((item) => item.id === Number(taskId));
+  if (!task) {
+    return;
+  }
+  editingTaskId = task.id;
+  const title = document.getElementById('config-task-form-title');
+  if (title) {
+    title.textContent = 'Editar tarefa';
+  }
+  const cancelButton = document.getElementById('config-task-cancel');
+  if (cancelButton) {
+    cancelButton.classList.remove('hidden');
+  }
+  document.getElementById('config-task-title').value = task.title;
+  document.getElementById('config-task-description').value = task.description || '';
+  document.getElementById('config-task-status').value = task.status;
+  document.getElementById('config-task-due').value = task.due_date || '';
+  populateTaskAssigneeSelect();
+  const ownerSelect = document.getElementById('config-task-owner');
+  if (ownerSelect) {
+    ownerSelect.value = task.assigned_to ? String(task.assigned_to.id) : '';
+  }
+}
+
+async function refreshTasksSection() {
+  const companyId = getActiveCompanyId();
+  if (!companyId) {
+    cachedTasks = [];
+    renderTaskList([]);
+    updateConfigCounts();
+    return;
+  }
+  try {
+    const tasks = await apiRequest(`/tasks?company_id=${companyId}`);
+    cachedTasks = tasks;
+    renderTaskList(tasks);
+    populateTaskAssigneeSelect();
+    updateConfigCounts();
+  } catch (error) {
+    setFeedback('config-task-feedback', error.message, true);
+  }
+}
+
+async function handleTaskSubmit(event) {
+  event.preventDefault();
+  const companyId = getActiveCompanyId();
+  if (!companyId && !editingTaskId) {
+    setFeedback('config-task-feedback', 'Escolha a empresa antes de salvar a tarefa.', true);
+    return;
+  }
+  const payload = {
+    title: document.getElementById('config-task-title').value.trim(),
+    description: normalizeStringValue(document.getElementById('config-task-description').value),
+    due_date: normalizeStringValue(document.getElementById('config-task-due').value),
+    status: document.getElementById('config-task-status').value,
+    assigned_to_id: normalizeStringValue(document.getElementById('config-task-owner').value)
+  };
+
+  if (!payload.title) {
+    setFeedback('config-task-feedback', 'Informe um título para a tarefa.', true);
+    return;
+  }
+
+  if (payload.assigned_to_id) {
+    payload.assigned_to_id = Number(payload.assigned_to_id);
+  } else {
+    payload.assigned_to_id = null;
+  }
+
+  const isEditing = Boolean(editingTaskId);
+  const url = isEditing ? `/tasks/${editingTaskId}` : '/tasks';
+  const method = isEditing ? 'PUT' : 'POST';
+  if (!isEditing) {
+    payload.company_id = companyId;
+  }
+  try {
+    await apiRequest(url, {
+      method,
+      body: JSON.stringify(payload)
+    });
+    setFeedback('config-task-feedback', 'Tarefa salva com sucesso!', false);
+    await refreshTasksSection();
+    await loadTaskSummary();
+    resetTaskForm();
+  } catch (error) {
+    setFeedback('config-task-feedback', error.message, true);
+  }
+}
+
+async function handleTaskListClick(event) {
+  const button = event.target.closest('button[data-action]');
+  if (!button) {
+    return;
+  }
+  const taskId = button.dataset.id;
+  if (button.dataset.action === 'edit') {
+    startTaskEdit(taskId);
+    return;
+  }
+  if (button.dataset.action === 'complete') {
+    try {
+      await apiRequest(`/tasks/${taskId}`, {
+        method: 'PUT',
+        body: JSON.stringify({ status: 'done' })
+      });
+      await refreshTasksSection();
+      await loadTaskSummary();
+    } catch (error) {
+      setFeedback('config-task-feedback', error.message, true);
+    }
+    return;
+  }
+  if (button.dataset.action === 'delete') {
+    const confirmed = window.confirm('Deseja remover esta tarefa?');
+    if (!confirmed) {
+      return;
+    }
+    try {
+      await apiRequest(`/tasks/${taskId}`, { method: 'DELETE' });
+      await refreshTasksSection();
+      await loadTaskSummary();
+      setFeedback('config-task-feedback', 'Tarefa removida.', false);
+    } catch (error) {
+      setFeedback('config-task-feedback', error.message, true);
+    }
+  }
+}
+
+async function showConfigTab(tab) {
+  currentConfigTab = tab;
+  const menuButtons = document.querySelectorAll('#config-menu button[data-tab]');
+  menuButtons.forEach((button) => {
+    button.classList.toggle('active', button.dataset.tab === tab);
+  });
+  const panels = document.querySelectorAll('.config-panel');
+  panels.forEach((panel) => {
+    const isActive = panel.dataset.panel === tab;
+    panel.classList.toggle('active', isActive);
+  });
+
+  if (tab === 'overview') {
+    await refreshCompaniesSection();
+    if (isAdminOrStaff()) {
+      await refreshUsersSection();
+    } else {
+      cachedUsers = [];
+      renderUserList([]);
+    }
+    await refreshAccountsSection();
+    await refreshCategoriesSection();
+    await refreshTransactionsSection();
+    await refreshGoalsSection();
+    await refreshTasksSection();
+    updateConfigCounts();
+  } else if (tab === 'companies') {
+    await refreshCompaniesSection();
+  } else if (tab === 'users') {
+    await refreshUsersSection();
+  } else if (tab === 'accounts') {
+    await refreshAccountsSection();
+  } else if (tab === 'categories') {
+    await refreshCategoriesSection();
+  } else if (tab === 'transactions') {
+    await refreshAccountsSection();
+    await refreshCategoriesSection();
+    await refreshTransactionsSection();
+  } else if (tab === 'imports') {
+    await refreshAccountsSection();
+    await refreshCategoriesSection();
+  } else if (tab === 'goals') {
+    await refreshGoalsSection();
+  } else if (tab === 'tasks') {
+    await refreshUsersSection();
+    await refreshTasksSection();
+  }
+}
+
+async function openConfigLayer() {
+  if (!currentUser) {
+    return;
+  }
+  const layer = document.getElementById('config-layer');
+  if (!layer) {
+    return;
+  }
+  layer.classList.remove('hidden');
+  layer.setAttribute('aria-hidden', 'false');
+  const initialTab = currentConfigTab === 'users' && !isAdminOrStaff() ? 'overview' : currentConfigTab;
+  try {
+    await showConfigTab(initialTab);
+  } catch (error) {
+    console.error('Falha ao carregar configurações:', error);
+    setFeedback('config-company-feedback', 'Não foi possível carregar as configurações.', true);
+  }
+  document.addEventListener('keydown', handleEscapeKey);
+}
+
+function closeConfigLayer() {
+  const layer = document.getElementById('config-layer');
+  if (!layer) {
+    return;
+  }
+  layer.classList.add('hidden');
+  layer.setAttribute('aria-hidden', 'true');
+  document.removeEventListener('keydown', handleEscapeKey);
+}
+
+async function handleConfigTabClick(event) {
+  const button = event.target.closest('button[data-tab]');
+  if (!button || button.classList.contains('hidden')) {
+    return;
+  }
+  const tab = button.dataset.tab;
+  try {
+    await showConfigTab(tab);
+  } catch (error) {
+    console.error('Erro ao trocar de aba de configuração:', error);
+  }
+}
+
+async function handleConfigCompanyChange(event) {
+  const value = event.target.value;
+  configCompanyId = value ? Number(value) : null;
+  populateUserCompanySelect();
+  try {
+    await refreshAccountsSection();
+    await refreshCategoriesSection();
+    await refreshTransactionsSection();
+    await refreshGoalsSection();
+    await refreshTasksSection();
+    await loadGoalSummary();
+    await loadTaskSummary();
+  } catch (error) {
+    console.error('Erro ao atualizar dados da empresa selecionada:', error);
+  }
+}
+
+function handleEscapeKey(event) {
+  if (event.key === 'Escape') {
+    const layer = document.getElementById('config-layer');
+    if (layer && !layer.classList.contains('hidden')) {
+      closeConfigLayer();
+    }
+  }
+}
+
+async function handleLogin(event) {
+  event.preventDefault();
+  const email = document.getElementById('email').value.trim();
+  const password = document.getElementById('password').value;
+  const errorElement = document.getElementById('login-error');
+  errorElement.textContent = '';
+  try {
+    const response = await apiRequest('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, password })
+    });
+    token = response.access_token;
+    currentUser = await apiRequest('/auth/me');
+    cachedCompanies = [];
+    cachedUsers = [];
+    cachedAccounts = [];
+    cachedCategories = [];
+    cachedTransactions = [];
+    cachedGoals = [];
+    cachedTasks = [];
+    configCompanyId = currentUser.role === 'client' ? currentUser.company_id || null : null;
+    currentConfigTab = 'overview';
+    editingCompanyId = null;
+    editingUserId = null;
+    editingGoalId = null;
+    editingTaskId = null;
+    resetCompanyForm();
+    resetUserForm();
+    const accountForm = document.getElementById('config-account-form');
+    if (accountForm) {
+      accountForm.reset();
+      const balanceField = document.getElementById('config-account-balance');
+      if (balanceField) {
+        balanceField.value = '0';
+      }
+    }
+    const categoryForm = document.getElementById('config-category-form');
+    if (categoryForm) {
+      categoryForm.reset();
+      const colorField = document.getElementById('config-category-color');
+      if (colorField) {
+        colorField.value = '#1f7a8c';
+      }
+    }
+    const transactionForm = document.getElementById('config-transaction-form');
+    if (transactionForm) {
+      transactionForm.reset();
+      const typeField = document.getElementById('config-transaction-type');
+      if (typeField) {
+        typeField.value = 'inflow';
+      }
+    }
+    const importForm = document.getElementById('config-import-form');
+    if (importForm) {
+      importForm.reset();
+    }
+    resetGoalForm();
+    resetTaskForm();
+    clearFeedback('config-account-feedback');
+    clearFeedback('config-category-feedback');
+    clearFeedback('config-transaction-feedback');
+    clearFeedback('config-import-feedback');
+    clearFeedback('config-goal-feedback');
+    clearFeedback('config-task-feedback');
+    updateRoleBasedUI();
+    populateTaskAssigneeSelect();
+    document.getElementById('welcome').textContent = `Olá, ${currentUser.full_name}!`;
+    toggleView(true);
+    await populateCompanies();
+    updatePeriodButtons(periodPreset);
+    await loadHighlights();
+    await loadFinancialReport();
+    await loadGoalSummary();
+    await loadTaskSummary();
+  } catch (error) {
+    errorElement.textContent = error.message;
+  }
+}
+
+function handleLogout() {
+  token = null;
+  currentUser = null;
+  selectedCompany = null;
+  periodPreset = '90';
+  cachedCompanies = [];
+  cachedUsers = [];
+  cachedAccounts = [];
+  cachedCategories = [];
+  cachedTransactions = [];
+  cachedGoals = [];
+  cachedTasks = [];
+  configCompanyId = null;
+  currentConfigTab = 'overview';
+  editingCompanyId = null;
+  editingUserId = null;
+  editingGoalId = null;
+  editingTaskId = null;
+  if (cashflowChart) {
+    cashflowChart.destroy();
+    cashflowChart = null;
+  }
+  closeConfigLayer();
+  resetCompanyForm();
+  resetUserForm();
+  const accountForm = document.getElementById('config-account-form');
+  if (accountForm) {
+    accountForm.reset();
+    const balanceField = document.getElementById('config-account-balance');
+    if (balanceField) {
+      balanceField.value = '0';
+    }
+  }
+  const categoryForm = document.getElementById('config-category-form');
+  if (categoryForm) {
+    categoryForm.reset();
+    const colorField = document.getElementById('config-category-color');
+    if (colorField) {
+      colorField.value = '#1f7a8c';
+    }
+  }
+  const transactionForm = document.getElementById('config-transaction-form');
+  if (transactionForm) {
+    transactionForm.reset();
+    const typeField = document.getElementById('config-transaction-type');
+    if (typeField) {
+      typeField.value = 'inflow';
+    }
+  }
+  const importForm = document.getElementById('config-import-form');
+  if (importForm) {
+    importForm.reset();
+  }
+  resetGoalForm();
+  resetTaskForm();
+  clearFeedback('config-company-feedback');
+  clearFeedback('config-user-feedback');
+  clearFeedback('config-account-feedback');
+  clearFeedback('config-category-feedback');
+  clearFeedback('config-transaction-feedback');
+  clearFeedback('config-import-feedback');
+  clearFeedback('config-goal-feedback');
+  clearFeedback('config-task-feedback');
+  updateRoleBasedUI();
+  updateConfigCounts();
+  document.getElementById('login-form').reset();
+  updatePeriodButtons(periodPreset);
+  toggleView(false);
+}
+
+async function handleExport() {
+  if (!currentUser) {
+    return;
+  }
+  const { start, end } = computePeriodRange(periodPreset);
+  let companyId = selectedCompany || currentUser.company_id;
+  if (!companyId) {
+    const companies = await apiRequest('/companies');
+    if (companies.length) {
+      companyId = companies[0].id;
+    }
+  }
+  if (!companyId) {
+    alert('Cadastre uma empresa para gerar o relatório.');
+    return;
+  }
+  const format = document.getElementById('export-format').value;
+  const response = await apiRequest(
+    `/reports/export?company_id=${companyId}&start_date=${start}&end_date=${end}&export_format=${format}`,
+    { method: 'GET' }
+  );
+  const blob = await response.blob();
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `relatorio-${format}.${format}`;
+  a.click();
+  window.URL.revokeObjectURL(url);
+}
+
+function handlePeriodChange(event) {
+  const button = event.target.closest('button[data-range]');
+  if (!button) {
+    return;
+  }
+  const { range } = button.dataset;
+  if (range === periodPreset) {
+    return;
+  }
+  periodPreset = range;
+  updatePeriodButtons(range);
+  loadFinancialReport();
+}
+
+function handleQuickExport() {
+  document.getElementById('export-report').click();
+}
+
+function registerEventListeners() {
+  document.getElementById('login-form').addEventListener('submit', handleLogin);
+  document.getElementById('logout').addEventListener('click', handleLogout);
+  document.getElementById('export-report').addEventListener('click', handleExport);
+  document.getElementById('quick-export').addEventListener('click', handleQuickExport);
+  document.querySelector('.period-selector').addEventListener('click', handlePeriodChange);
+  document.getElementById('company-picker').addEventListener('change', (event) => {
+    const value = event.target.value;
+    selectedCompany = value ? Number(value) : null;
+    loadFinancialReport();
+    loadGoalSummary();
+    loadTaskSummary();
+  });
+  document.getElementById('open-config').addEventListener('click', (event) => {
+    event.preventDefault();
+    openConfigLayer();
+  });
+  document.getElementById('close-config').addEventListener('click', (event) => {
+    event.preventDefault();
+    closeConfigLayer();
+  });
+  document.getElementById('config-menu').addEventListener('click', handleConfigTabClick);
+  document.getElementById('config-company-form').addEventListener('submit', handleCompanySubmit);
+  document.getElementById('config-company-cancel').addEventListener('click', resetCompanyForm);
+  document.getElementById('config-company-list').addEventListener('click', handleCompanyListClick);
+  document.getElementById('config-user-form').addEventListener('submit', handleUserSubmit);
+  document.getElementById('config-user-cancel').addEventListener('click', resetUserForm);
+  document.getElementById('config-user-list').addEventListener('click', handleUserListClick);
+  document.getElementById('config-account-form').addEventListener('submit', handleAccountSubmit);
+  document.getElementById('config-category-form').addEventListener('submit', handleCategorySubmit);
+  document.getElementById('config-transaction-form').addEventListener('submit', handleTransactionSubmit);
+  document.getElementById('config-import-form').addEventListener('submit', handleImportSubmit);
+  document.getElementById('config-goal-form').addEventListener('submit', handleGoalSubmit);
+  document.getElementById('config-goal-cancel').addEventListener('click', resetGoalForm);
+  document.getElementById('config-goal-list').addEventListener('click', handleGoalListClick);
+  document.getElementById('config-task-form').addEventListener('submit', handleTaskSubmit);
+  document.getElementById('config-task-cancel').addEventListener('click', resetTaskForm);
+  document.getElementById('config-task-list').addEventListener('click', handleTaskListClick);
+  document.getElementById('config-company-focus').addEventListener('change', handleConfigCompanyChange);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  registerEventListeners();
+  updatePeriodButtons(periodPreset);
+});

--- a/bpo_app/frontend/styles.css
+++ b/bpo_app/frontend/styles.css
@@ -1,0 +1,1207 @@
+:root {
+  --bg: #f3f5f9;
+  --bg-alt: #ffffff;
+  --surface: rgba(255, 255, 255, 0.72);
+  --border: rgba(15, 23, 42, 0.08);
+  --primary: #1f7a8c;
+  --primary-strong: #176275;
+  --accent: #3cb7a0;
+  --accent-soft: rgba(60, 183, 160, 0.1);
+  --text: #0f172a;
+  --text-muted: #4b5563;
+  --danger: #d64045;
+  --success: #1b998b;
+  --warning: #f4a261;
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #e8f6ff 0%, #f9fbfc 45%, #eef2f7 100%);
+  color: var(--text);
+}
+
+.hidden {
+  display: none !important;
+}
+
+.app-shell {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 2rem clamp(1rem, 3vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.25rem 1.75rem;
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(31, 122, 140, 0.9), rgba(60, 183, 160, 0.9));
+  color: #f8fafc;
+  box-shadow: var(--shadow);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.15);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 1.5rem;
+}
+
+.brand-text h1 {
+  font-size: clamp(1.4rem, 2.8vw, 1.8rem);
+  margin: 0;
+}
+
+.brand-text p {
+  margin: 0.25rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(248, 250, 252, 0.88);
+}
+
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.main-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.panel {
+  background: var(--surface);
+  border-radius: 28px;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  display: flex;
+  gap: 2rem;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  backdrop-filter: blur(14px);
+  box-shadow: var(--shadow);
+}
+
+.panel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.login-panel {
+  flex-wrap: wrap;
+}
+
+.panel-body {
+  flex: 1 1 320px;
+  min-width: 280px;
+}
+
+.panel-description {
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+  max-width: 420px;
+}
+
+.panel-aside {
+  flex: 1 1 260px;
+  min-width: 240px;
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 20px;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.panel-aside h3 {
+  margin-top: 0;
+}
+
+.panel-aside ul {
+  padding-left: 1.2rem;
+  margin: 0 0 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.panel-note {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.form label {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.form input,
+select {
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.form input:focus,
+select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(31, 122, 140, 0.18);
+}
+
+.primary-button,
+.secondary-button,
+.ghost-button,
+.chip {
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  border-radius: 999px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  font-size: 0.95rem;
+}
+
+.primary-button {
+  padding: 0.9rem 1.8rem;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: #fff;
+  box-shadow: 0 14px 24px rgba(31, 122, 140, 0.35);
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(23, 98, 117, 0.35);
+}
+
+.secondary-button {
+  padding: 0.8rem 1.6rem;
+  background: rgba(31, 122, 140, 0.1);
+  color: var(--primary);
+}
+
+.secondary-button:hover {
+  background: rgba(31, 122, 140, 0.18);
+}
+
+.ghost-button {
+  padding: 0.65rem 1.3rem;
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.ghost-button:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.chip {
+  padding: 0.55rem 1.1rem;
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text);
+  margin: 0;
+}
+
+.chip.active {
+  background: rgba(31, 122, 140, 0.18);
+  color: var(--primary-strong);
+  box-shadow: 0 8px 16px rgba(31, 122, 140, 0.12);
+}
+
+.feedback {
+  min-height: 1.25rem;
+  color: var(--danger);
+  font-size: 0.95rem;
+}
+
+.dashboard {
+  width: 100%;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.panel.stretch {
+  grid-column: 1 / -1;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.muted {
+  color: var(--text-muted);
+  margin: 0.35rem 0 0;
+}
+
+.selector-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.company-selector {
+  display: grid;
+  gap: 0.4rem;
+  min-width: 220px;
+}
+
+.company-selector label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.period-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.highlight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.highlight-card {
+  padding: 1.25rem 1.4rem;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  position: relative;
+  overflow: hidden;
+}
+
+.highlight-card::before {
+  content: "";
+  position: absolute;
+  top: -40px;
+  right: -40px;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  transition: transform 0.3s ease;
+}
+
+.highlight-card:hover::before {
+  transform: translate(-8px, 8px);
+}
+
+.highlight-card span {
+  display: block;
+}
+
+.highlight-card .title {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.highlight-card .value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin: 0.4rem 0;
+}
+
+.highlight-card.positive .value {
+  color: var(--success);
+}
+
+.highlight-card.negative .value {
+  color: var(--danger);
+}
+
+.highlight-card .description {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.chart-panel,
+.dre-panel,
+.list-panel,
+.contact-panel {
+  flex-direction: column;
+}
+
+.chart-panel {
+  min-height: 360px;
+}
+
+.chart-panel canvas {
+  width: 100%;
+  min-height: 220px;
+}
+
+.table-wrapper {
+  margin-top: 1.5rem;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+#cashflow-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(255, 255, 255, 0.92);
+}
+
+#cashflow-table th,
+#cashflow-table td {
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-size: 0.95rem;
+}
+
+#cashflow-table tbody tr:nth-child(odd) {
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.dre-message {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.dre-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.dre-list li {
+  background: rgba(31, 122, 140, 0.08);
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  font-weight: 500;
+}
+
+.download-card {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.status-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.status-item {
+  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.status-item.positive {
+  border-color: rgba(27, 153, 139, 0.3);
+}
+
+.status-item.negative {
+  border-color: rgba(214, 64, 69, 0.25);
+}
+
+.status-meta {
+  display: flex;
+  flex-direction: column;
+}
+
+.status-meta span:first-child {
+  font-weight: 600;
+}
+
+.status-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  align-items: flex-end;
+}
+
+.status-chip {
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text-muted);
+}
+
+.status-date {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.status-amount {
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.empty-state {
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px dashed rgba(15, 23, 42, 0.2);
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.contact-panel {
+  grid-column: 1 / -1;
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.2rem;
+}
+
+.contact-label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.contact-value {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.contact-tip {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.footer {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  padding-bottom: 1rem;
+}
+
+@media (max-width: 960px) {
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .top-actions {
+    align-self: stretch;
+    justify-content: flex-end;
+    width: 100%;
+  }
+}
+
+@media (max-width: 720px) {
+  .panel {
+    padding: 1.5rem;
+  }
+
+  .panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .selector-group {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .period-selector {
+    width: 100%;
+  }
+
+  .chip {
+    flex: 1 1 calc(50% - 0.6rem);
+    text-align: center;
+  }
+}
+
+@media (max-width: 540px) {
+  .brand {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .panel-aside {
+    padding: 1rem;
+  }
+
+  .download-card {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+.config-layer {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 2.5rem 1.5rem;
+  background: rgba(6, 23, 35, 0.75);
+  overflow-y: auto;
+  z-index: 20;
+}
+
+.config-container {
+  width: min(1080px, 100%);
+  background: #f9fbfc;
+  border-radius: 20px;
+  box-shadow: 0 24px 60px rgba(5, 22, 33, 0.35);
+  padding: 2rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  color: #0f2a3a;
+}
+
+.config-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.config-header h2 {
+  margin-bottom: 0.35rem;
+  color: #0b2130;
+}
+
+.config-focus {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.config-focus select {
+  width: 260px;
+  padding: 0.6rem 0.85rem;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 42, 58, 0.15);
+  background: white;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.config-body {
+  display: flex;
+  gap: 1.75rem;
+}
+
+.config-menu {
+  flex: 0 0 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.config-menu button {
+  text-align: left;
+  padding: 0.7rem 0.9rem;
+  border-radius: 12px;
+  border: none;
+  background: rgba(31, 122, 140, 0.1);
+  color: #0f2a3a;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.config-menu button:hover {
+  background: rgba(31, 122, 140, 0.2);
+}
+
+.config-menu button.active {
+  background: linear-gradient(135deg, #1f7a8c, #3cb7a0);
+  color: white;
+  box-shadow: 0 12px 20px rgba(31, 122, 140, 0.35);
+}
+
+.config-panels {
+  flex: 1;
+  background: white;
+  border-radius: 18px;
+  box-shadow: 0 16px 30px rgba(12, 45, 58, 0.15);
+  padding: 1.75rem 2rem;
+  max-height: 70vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.config-panel {
+  display: none;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.config-panel.active {
+  display: flex;
+}
+
+.config-panel-header h3 {
+  margin-bottom: 0.2rem;
+  color: #0f2a3a;
+}
+
+.config-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.config-stat {
+  background: rgba(31, 122, 140, 0.08);
+  padding: 1.1rem;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border: 1px solid rgba(31, 122, 140, 0.15);
+}
+
+.config-stat-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #1f7a8c;
+}
+
+.config-stat-label {
+  font-size: 0.9rem;
+  color: rgba(15, 42, 58, 0.65);
+}
+
+.config-hints {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.hint-card {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 16px;
+  border: 1px solid rgba(15, 42, 58, 0.12);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hint-card h4 {
+  font-size: 1rem;
+  color: #0f2a3a;
+}
+
+.config-columns {
+  display: grid;
+  grid-template-columns: minmax(220px, 1.2fr) minmax(240px, 1fr);
+  gap: 1.5rem;
+}
+
+.config-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.inline-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.inline-checkbox input {
+  margin: 0;
+}
+
+.goal-progress-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.goal-progress-card {
+  border: 1px solid rgba(15, 42, 58, 0.1);
+  border-radius: 16px;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.88);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.goal-progress-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.goal-progress-values {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+  color: #0f2a3a;
+}
+
+.goal-progress-card footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+}
+
+.goal-progress-card.status-missed {
+  border-color: rgba(214, 64, 69, 0.28);
+}
+
+.goal-progress-card.status-achieved {
+  border-color: rgba(27, 153, 139, 0.25);
+}
+
+.goal-progress-bar {
+  position: relative;
+  height: 8px;
+  background: rgba(31, 122, 140, 0.12);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.goal-progress-bar div {
+  height: 100%;
+  background: linear-gradient(135deg, #1f7a8c, #3cb7a0);
+  border-radius: inherit;
+  transition: width 0.25s ease;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.status-pill.status-in_progress {
+  background: rgba(31, 122, 140, 0.16);
+  color: #1f7a8c;
+}
+
+.status-pill.status-achieved {
+  background: rgba(27, 153, 139, 0.18);
+  color: #1b998b;
+}
+
+.status-pill.status-missed {
+  background: rgba(214, 64, 69, 0.18);
+  color: #d64045;
+}
+
+.status-pill.status-archived {
+  background: rgba(71, 85, 105, 0.18);
+  color: #475569;
+}
+
+.goal-metrics,
+.task-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.metric-card {
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(15, 42, 58, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.metric-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.metric-value {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #0f2a3a;
+}
+
+.metric-value.positive {
+  color: #1b998b;
+}
+
+.metric-value.warning {
+  color: #d64045;
+}
+
+.goal-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.goal-summary-card {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 18px;
+  border: 1px solid rgba(15, 42, 58, 0.12);
+  padding: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  box-shadow: 0 14px 26px rgba(15, 42, 58, 0.08);
+}
+
+.goal-summary-card.status-missed {
+  border-color: rgba(214, 64, 69, 0.28);
+}
+
+.goal-summary-card.status-achieved {
+  border-color: rgba(27, 153, 139, 0.28);
+}
+
+.goal-summary-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.goal-summary-direction {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.goal-summary-values {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+  color: #0f2a3a;
+}
+
+.goal-summary-status {
+  align-self: flex-start;
+}
+
+.task-summary-item {
+  list-style: none;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 16px;
+  border: 1px solid rgba(15, 42, 58, 0.12);
+  padding: 0.9rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: 0 12px 22px rgba(15, 42, 58, 0.07);
+}
+
+.task-summary-title strong {
+  font-weight: 600;
+}
+
+.task-summary-title p {
+  margin: 0;
+}
+
+.task-summary-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.task-summary-chip {
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.task-summary-chip.status-open {
+  background: rgba(31, 122, 140, 0.16);
+  color: #1f7a8c;
+}
+
+.task-summary-chip.status-in_progress {
+  background: rgba(244, 162, 97, 0.22);
+  color: #c05621;
+}
+
+.task-summary-chip.status-done {
+  background: rgba(27, 153, 139, 0.2);
+  color: #1b998b;
+}
+
+.task-summary-date {
+  font-weight: 600;
+}
+
+.task-summary-owner {
+  font-style: italic;
+}
+
+.task-summary-more {
+  list-style: none;
+  text-align: center;
+  padding: 0.5rem 0;
+}
+
+.config-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.config-list li {
+  background: rgba(15, 42, 58, 0.05);
+  border-radius: 14px;
+  padding: 0.8rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.config-list li .item-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.config-list li .item-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.config-list button.inline {
+  border: none;
+  background: none;
+  color: #1f7a8c;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.config-list button.inline:hover {
+  text-decoration: underline;
+}
+
+.config-form {
+  background: rgba(31, 122, 140, 0.06);
+  border-radius: 16px;
+  padding: 1.2rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.config-form.disabled {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.config-form.single {
+  max-width: 480px;
+}
+
+.config-form h4 {
+  margin-bottom: 0.2rem;
+  color: #0f2a3a;
+}
+
+.config-form label {
+  font-size: 0.85rem;
+  color: rgba(15, 42, 58, 0.75);
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.config-form input,
+.config-form select,
+.config-form textarea {
+  border-radius: 10px;
+  border: 1px solid rgba(15, 42, 58, 0.15);
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  font-family: inherit;
+  background: white;
+  color: #0f2a3a;
+}
+
+.config-form textarea {
+  resize: vertical;
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.ghost-button.small {
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.config-feedback {
+  font-size: 0.85rem;
+  min-height: 1.2rem;
+}
+
+.config-feedback.success {
+  color: #1f7a8c;
+}
+
+.config-feedback.error {
+  color: #d64045;
+}
+
+.config-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(255, 255, 255, 0.65);
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(15, 42, 58, 0.08);
+}
+
+.config-table th,
+.config-table td {
+  padding: 0.75rem 0.9rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(15, 42, 58, 0.08);
+  font-size: 0.9rem;
+}
+
+.config-table tbody tr:nth-child(even) {
+  background: rgba(15, 42, 58, 0.04);
+}
+
+.config-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.muted.small {
+  font-size: 0.8rem;
+}
+
+@media (max-width: 1100px) {
+  .config-body {
+    flex-direction: column;
+  }
+
+  .config-menu {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .config-menu button {
+    flex: 1 1 150px;
+    text-align: center;
+  }
+
+  .config-panels {
+    max-height: none;
+  }
+
+  .config-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .config-container {
+    padding: 1.5rem;
+  }
+
+  .config-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .config-focus select {
+    width: 100%;
+  }
+
+  .config-layer {
+    padding: 1.5rem 1rem;
+  }
+}

--- a/bpo_app/importers.py
+++ b/bpo_app/importers.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import csv
+import io
+from datetime import datetime
+from typing import List
+
+import pandas as pd
+from fastapi import HTTPException, UploadFile, status
+from ofxparse import OfxParser
+
+from .models import TransactionType
+
+EXPECTED_COLUMNS = {"data", "descricao", "valor", "tipo"}
+
+
+def normalize_record(record: dict) -> dict:
+    description = str(record.get("descricao") or record.get("description") or "").strip()
+    amount_raw = record.get("valor") or record.get("amount") or 0
+    txn_type_raw = str(record.get("tipo") or record.get("type") or "").lower()
+    date_raw = record.get("data") or record.get("date")
+
+    if isinstance(date_raw, datetime):
+        date_value = date_raw.date()
+    elif isinstance(date_raw, str):
+        for fmt in ("%Y-%m-%d", "%d/%m/%Y", "%d-%m-%Y", "%d.%m.%Y"):
+            try:
+                date_value = datetime.strptime(date_raw.strip(), fmt).date()
+                break
+            except ValueError:
+                continue
+        else:
+            raise HTTPException(status_code=400, detail=f"Data inválida: {date_raw}")
+    else:
+        raise HTTPException(status_code=400, detail="Coluna de data ausente")
+
+    if isinstance(amount_raw, str):
+        cleaned = amount_raw.replace("R$", "").replace(" ", "").replace(".", "").replace(",", ".")
+        try:
+            amount = float(cleaned)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=f"Valor inválido: {amount_raw}") from exc
+    else:
+        amount = float(amount_raw)
+    if txn_type_raw in {"entrada", "receita", "credito", "in"}:
+        txn_type = TransactionType.INFLOW
+    elif txn_type_raw in {"saida", "despesa", "debito", "out"}:
+        txn_type = TransactionType.OUTFLOW
+    else:
+        txn_type = TransactionType.INFLOW if amount >= 0 else TransactionType.OUTFLOW
+
+    return {
+        "date": date_value,
+        "description": description,
+        "amount": abs(amount),
+        "transaction_type": txn_type,
+    }
+
+
+def read_csv(file_bytes: bytes) -> List[dict]:
+    text_stream = io.StringIO(file_bytes.decode("utf-8-sig"))
+    sample = text_stream.read(2048)
+    text_stream.seek(0)
+    try:
+        dialect = csv.Sniffer().sniff(sample)
+    except csv.Error:
+        dialect = csv.excel
+    reader = csv.DictReader(text_stream, dialect=dialect)
+    records = [normalize_record(row) for row in reader]
+    return records
+
+
+def read_excel(file_bytes: bytes) -> List[dict]:
+    stream = io.BytesIO(file_bytes)
+    df = pd.read_excel(stream)
+    df.columns = [col.strip().lower() for col in df.columns]
+    if not EXPECTED_COLUMNS.issubset(set(df.columns)):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Planilha deve conter colunas: data, descricao, valor, tipo",
+        )
+    records = [normalize_record(row) for row in df.to_dict(orient="records")]
+    return records
+
+
+def read_ofx(file_bytes: bytes) -> List[dict]:
+    stream = io.BytesIO(file_bytes)
+    ofx = OfxParser.parse(stream)
+    records: List[dict] = []
+    for account in ofx.accounts:
+        for transaction in account.statement.transactions:
+            txn_type = (
+                TransactionType.INFLOW
+                if transaction.amount >= 0
+                else TransactionType.OUTFLOW
+            )
+            records.append(
+                {
+                    "date": transaction.date.date(),
+                    "description": transaction.memo or transaction.payee or "OFX",
+                    "amount": abs(transaction.amount),
+                    "transaction_type": txn_type,
+                }
+            )
+    return records
+
+
+def parse_upload(file: UploadFile) -> List[dict]:
+    content = file.file.read()
+    filename = file.filename or "arquivo"
+    suffix = filename.split(".")[-1].lower()
+
+    if suffix in {"csv"}:
+        return read_csv(content)
+    if suffix in {"xls", "xlsx"}:
+        return read_excel(content)
+    if suffix == "ofx":
+        return read_ofx(content)
+
+    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Formato não suportado")

--- a/bpo_app/main.py
+++ b/bpo_app/main.py
@@ -1,0 +1,1243 @@
+from __future__ import annotations
+
+import io
+import logging
+import os
+from datetime import date, datetime, timedelta
+from typing import Optional
+
+import pandas as pd
+from fastapi import Depends, FastAPI, File, HTTPException, UploadFile, status
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from . import database
+from .auth import (
+    create_access_token,
+    get_current_user,
+    get_password_hash,
+    require_role,
+    set_secret_key,
+    verify_password,
+)
+from .classifier import classify_transaction, ensure_default_categories
+from .database import get_db
+from .importers import parse_upload
+from .models import (
+    BankAccount,
+    Category,
+    ChecklistTask,
+    Company,
+    FinancialGoal,
+    TaskStatus,
+    Transaction,
+    TransactionType,
+    UploadLog,
+    User,
+    UserRole,
+)
+from .nfse_client import (
+    NFSeClient,
+    NFSeClientConfig,
+    NFSeConfigurationError,
+    NFSeOperationError,
+    NFSeServiceError,
+)
+from .nfse_goiania import build_goiania_payload
+from .schemas import (
+    BankAccountCreate,
+    BankAccountRead,
+    BankAccountUpdate,
+    CashFlowEntry,
+    CategoryCreate,
+    CategoryRead,
+    CategoryUpdate,
+    ChecklistTaskCreate,
+    ChecklistTaskRead,
+    ChecklistTaskUpdate,
+    CompanyCreate,
+    CompanyRead,
+    CompanyUpdate,
+    CurrentUser,
+    DRESummary,
+    DashboardHighlight,
+    FinancialGoalCreate,
+    FinancialGoalProgress,
+    FinancialGoalRead,
+    FinancialGoalUpdate,
+    FinancialGoalSummary,
+    FinancialHealthReport,
+    GoalStatus,
+    LoginRequest,
+    GoianiaNfseEmissionRequest,
+    NFSeCallRequest,
+    NFSeCallResponse,
+    OutstandingEntry,
+    SimpleMessage,
+    TokenResponse,
+    TransactionCreate,
+    TransactionRead,
+    TransactionUpdate,
+    UploadSummary,
+    UserCreate,
+    UserRead,
+    UserUpdate,
+    TaskSummary,
+)
+from .settings import get_settings
+
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+_nfse_client: Optional[NFSeClient] = None
+_nfse_config: Optional[NFSeClientConfig] = None
+
+
+def _build_nfse_config(payload: NFSeCallRequest) -> Optional[NFSeClientConfig]:
+    wsdl_url = payload.wsdl_url or settings.nfse_wsdl_url
+    if not wsdl_url:
+        return None
+    timeout = payload.timeout or settings.nfse_timeout
+    verify_ssl = payload.verify_ssl if payload.verify_ssl is not None else settings.nfse_verify_ssl
+    return NFSeClientConfig(
+        wsdl_url=wsdl_url,
+        service_url=payload.service_url or settings.nfse_service_url,
+        timeout=timeout,
+        verify_ssl=verify_ssl,
+    )
+
+
+def resolve_nfse_client(config: NFSeClientConfig, use_cache: bool = True) -> NFSeClient:
+    global _nfse_client, _nfse_config
+    if not use_cache:
+        return NFSeClient(config)
+    if _nfse_client is None or _nfse_config != config:
+        _nfse_client = NFSeClient(config)
+        _nfse_config = config
+    return _nfse_client
+
+
+def format_brl(value: float) -> str:
+    return f"R$ {value:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
+
+
+def resolve_company_id(company_id: Optional[int], current_user: CurrentUser) -> int:
+    if current_user.role == UserRole.CLIENT:
+        if not current_user.company_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Seu usuário não está vinculado a nenhuma empresa.",
+            )
+        if company_id and company_id != current_user.company_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Você só pode acessar dados da sua empresa.",
+            )
+        return current_user.company_id
+    if company_id is None:
+        raise HTTPException(status_code=400, detail="Informe a empresa desejada.")
+    return company_id
+
+
+def ensure_company_exists(db: Session, company_id: int) -> Company:
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(status_code=404, detail="Empresa não encontrada")
+    return company
+
+
+def ensure_company_access(company_id: int, current_user: CurrentUser) -> None:
+    if current_user.role == UserRole.CLIENT and current_user.company_id != company_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Ação permitida apenas para a sua empresa.",
+        )
+
+
+def calculate_goal_progress(db: Session, goal: FinancialGoal) -> FinancialGoalProgress:
+    total = (
+        db.query(func.coalesce(func.sum(Transaction.amount), 0))
+        .filter(
+            Transaction.company_id == goal.company_id,
+            Transaction.transaction_type == goal.direction,
+            Transaction.date >= goal.period_start,
+            Transaction.date <= goal.period_end,
+        )
+        .scalar()
+    )
+    actual_amount = float(total or 0)
+    target_amount = float(goal.target_amount or 0)
+    remaining_amount = max(target_amount - actual_amount, 0.0)
+    today = date.today()
+
+    if goal.direction == TransactionType.INFLOW:
+        achieved = actual_amount >= target_amount and target_amount > 0
+        status = GoalStatus.ACHIEVED if achieved else GoalStatus.IN_PROGRESS
+        if today > goal.period_end and not achieved:
+            status = GoalStatus.MISSED
+        progress_percentage = (
+            min(100.0, (actual_amount / target_amount) * 100) if target_amount else 0.0
+        )
+        if status == GoalStatus.ACHIEVED:
+            message = "Meta atingida! Continue acompanhando o período."
+        elif status == GoalStatus.MISSED:
+            message = "O período encerrou antes de atingir a meta. Revise os próximos passos."
+        else:
+            message = f"Faltam {format_brl(remaining_amount)} para chegar ao objetivo."
+    else:
+        consumed_percentage = (
+            min(100.0, (actual_amount / target_amount) * 100) if target_amount else 0.0
+        )
+        status = GoalStatus.IN_PROGRESS
+        if actual_amount > target_amount and target_amount > 0:
+            status = GoalStatus.MISSED
+        if today > goal.period_end:
+            status = GoalStatus.ACHIEVED if actual_amount <= target_amount else GoalStatus.MISSED
+        progress_percentage = consumed_percentage
+        remaining_amount = (
+            max(target_amount - actual_amount, 0.0) if actual_amount <= target_amount else 0.0
+        )
+        if status == GoalStatus.MISSED:
+            message = "Os gastos passaram do limite planejado. Ajuste o próximo período."
+        elif status == GoalStatus.ACHIEVED:
+            message = "Período encerrado com gastos dentro do limite esperado."
+        else:
+            message = f"Limite disponível de {format_brl(remaining_amount)} até o fim do período."
+
+    return FinancialGoalProgress(
+        goal=FinancialGoalRead.model_validate(goal),
+        actual_amount=actual_amount,
+        remaining_amount=remaining_amount,
+        progress_percentage=round(progress_percentage, 2),
+        status=status,
+        message=message,
+    )
+
+
+def serialize_task(task: ChecklistTask) -> ChecklistTaskRead:
+    return ChecklistTaskRead.model_validate(task)
+
+
+app = FastAPI(title="BPO Financeiro Simples", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+FRONTEND_DIR = os.path.join(os.path.dirname(__file__), "frontend")
+if os.path.isdir(FRONTEND_DIR):
+    app.mount("/app", StaticFiles(directory=FRONTEND_DIR, html=True), name="frontend")
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    if database.engine is None:
+        database.init_engine()
+
+    database.Base.metadata.create_all(bind=database.engine)
+    set_secret_key(settings.secret_key)
+
+    if settings.secret_key == "troque-essa-chave":
+        logger.warning(
+            "BPO_SECRET_KEY não definido. Use um valor forte antes de rodar em produção."
+        )
+
+    session_factory = database.get_sessionmaker()
+    with session_factory() as db:
+        admin_email = (settings.admin_email or "admin@bpo.exemplo.com").strip().lower()
+        admin_password = settings.admin_password or "admin123"
+
+        admin = db.query(User).filter(func.lower(User.email) == admin_email).first()
+        created_admin = False
+
+        if admin is None:
+            admin = User(
+                full_name=settings.admin_name or "Administrador",
+                email=admin_email,
+                password_hash=get_password_hash(admin_password),
+                role=UserRole.ADMIN,
+            )
+            db.add(admin)
+            db.commit()
+            db.refresh(admin)
+            created_admin = True
+            logger.info(
+                "Administrador padrão criado com o e-mail %s. Atualize a senha após o primeiro login.",
+                admin_email,
+            )
+
+        updates_performed = False
+
+        if admin.role != UserRole.ADMIN:
+            admin.role = UserRole.ADMIN
+            updates_performed = True
+
+        if settings.admin_password_from_env and settings.admin_password:
+            if not verify_password(settings.admin_password, admin.password_hash):
+                admin.password_hash = get_password_hash(settings.admin_password)
+                updates_performed = True
+                logger.info(
+                    "Senha do administrador %s sincronizada com o valor definido em BPO_ADMIN_PASSWORD.",
+                    admin_email,
+                )
+
+        if updates_performed:
+            db.commit()
+
+        if created_admin and admin_password == "admin123":
+            logger.warning(
+                "BPO_ADMIN_PASSWORD não definido. A senha padrão 'admin123' está em uso.",
+            )
+
+
+
+@app.get("/", response_class=HTMLResponse)
+def root_page() -> str:
+    if os.path.isdir(FRONTEND_DIR):
+        with open(os.path.join(FRONTEND_DIR, "index.html"), "r", encoding="utf-8") as f:
+            return f.read()
+    return "<h1>BPO Financeiro Simples</h1><p>Aplicação em execução.</p>"
+
+
+@app.post("/auth/login", response_model=TokenResponse)
+def login(request: LoginRequest, db: Session = Depends(get_db)) -> TokenResponse:
+    email = request.email.strip().lower()
+    user = db.query(User).filter(func.lower(User.email) == email).first()
+    if not user or not verify_password(request.password, user.password_hash):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Credenciais inválidas")
+
+    token = create_access_token({"sub": user.id, "role": user.role.value})
+    return TokenResponse(access_token=token)
+
+
+@app.get("/auth/me", response_model=UserRead)
+def read_current_user(current_user: CurrentUser = Depends(get_current_user), db: Session = Depends(get_db)) -> UserRead:
+    user = db.query(User).filter(User.id == current_user.id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Usuário não encontrado")
+    return UserRead.model_validate(user)
+
+
+@app.post("/companies", response_model=CompanyRead)
+def create_company(
+    payload: CompanyCreate,
+    db: Session = Depends(get_db),
+    _: CurrentUser = Depends(require_role(UserRole.ADMIN, UserRole.STAFF)),
+) -> CompanyRead:
+    company = Company(**payload.model_dump())
+    db.add(company)
+    db.commit()
+    db.refresh(company)
+    ensure_default_categories(db, company.id)
+    return CompanyRead.model_validate(company)
+
+
+@app.get("/companies", response_model=list[CompanyRead])
+def list_companies(
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[CompanyRead]:
+    query = db.query(Company)
+    if current_user.role == UserRole.CLIENT:
+        query = query.filter(Company.id == current_user.company_id)
+    companies = query.order_by(Company.name.asc()).all()
+    return [CompanyRead.model_validate(company) for company in companies]
+
+
+@app.put("/companies/{company_id}", response_model=CompanyRead)
+def update_company(
+    company_id: int,
+    payload: CompanyUpdate,
+    db: Session = Depends(get_db),
+    _: CurrentUser = Depends(require_role(UserRole.ADMIN, UserRole.STAFF)),
+) -> CompanyRead:
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(status_code=404, detail="Empresa não encontrada")
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(company, key, value)
+    db.commit()
+    db.refresh(company)
+    return CompanyRead.model_validate(company)
+
+
+@app.delete("/companies/{company_id}", response_model=SimpleMessage)
+def delete_company(
+    company_id: int,
+    db: Session = Depends(get_db),
+    _: CurrentUser = Depends(require_role(UserRole.ADMIN)),
+) -> SimpleMessage:
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(status_code=404, detail="Empresa não encontrada")
+    db.delete(company)
+    db.commit()
+    return SimpleMessage(message="Empresa removida com sucesso")
+
+
+@app.post("/users", response_model=UserRead)
+def create_user(
+    payload: UserCreate,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(UserRole.ADMIN, UserRole.STAFF)),
+) -> UserRead:
+    if payload.role == UserRole.CLIENT and not payload.company_id:
+        raise HTTPException(status_code=400, detail="Cliente precisa estar vinculado a uma empresa")
+    user = User(
+        full_name=payload.full_name,
+        email=payload.email.lower(),
+        password_hash=get_password_hash(payload.password),
+        role=payload.role,
+        company_id=payload.company_id,
+        is_active=payload.is_active,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserRead.model_validate(user)
+
+
+@app.get("/users", response_model=list[UserRead])
+def list_users(
+    current_user: CurrentUser = Depends(require_role(UserRole.ADMIN, UserRole.STAFF)),
+    db: Session = Depends(get_db),
+) -> list[UserRead]:
+    users = db.query(User).order_by(User.created_at.desc()).all()
+    return [UserRead.model_validate(user) for user in users]
+
+
+@app.put("/users/{user_id}", response_model=UserRead)
+def update_user(
+    user_id: int,
+    payload: UserUpdate,
+    db: Session = Depends(get_db),
+    _: CurrentUser = Depends(require_role(UserRole.ADMIN, UserRole.STAFF)),
+) -> UserRead:
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Usuário não encontrado")
+    update_data = payload.model_dump(exclude_unset=True)
+    if "password" in update_data and update_data["password"]:
+        user.password_hash = get_password_hash(update_data.pop("password"))
+    for key, value in update_data.items():
+        setattr(user, key, value)
+    db.commit()
+    db.refresh(user)
+    return UserRead.model_validate(user)
+
+
+@app.post("/bank-accounts", response_model=BankAccountRead)
+def create_bank_account(
+    payload: BankAccountCreate,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> BankAccountRead:
+    if current_user.role == UserRole.CLIENT and current_user.company_id != payload.company_id:
+        raise HTTPException(status_code=403, detail="Conta bancária deve pertencer à sua empresa")
+    account = BankAccount(**payload.model_dump())
+    db.add(account)
+    db.commit()
+    db.refresh(account)
+    return BankAccountRead.model_validate(account)
+
+
+@app.get("/bank-accounts", response_model=list[BankAccountRead])
+def list_bank_accounts(
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    company_id: Optional[int] = None,
+) -> list[BankAccountRead]:
+    query = db.query(BankAccount)
+    if current_user.role == UserRole.CLIENT:
+        query = query.filter(BankAccount.company_id == current_user.company_id)
+    elif company_id:
+        query = query.filter(BankAccount.company_id == company_id)
+    accounts = query.order_by(BankAccount.name.asc()).all()
+    return [BankAccountRead.model_validate(account) for account in accounts]
+
+
+@app.post("/categories", response_model=CategoryRead)
+def create_category(
+    payload: CategoryCreate,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> CategoryRead:
+    if current_user.role == UserRole.CLIENT and payload.company_id != current_user.company_id:
+        raise HTTPException(status_code=403, detail="Categoria deve pertencer à sua empresa")
+    category = Category(**payload.model_dump())
+    db.add(category)
+    db.commit()
+    db.refresh(category)
+    return CategoryRead.model_validate(category)
+
+
+@app.get("/categories", response_model=list[CategoryRead])
+def list_categories(
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    company_id: Optional[int] = None,
+) -> list[CategoryRead]:
+    query = db.query(Category)
+    if current_user.role == UserRole.CLIENT:
+        query = query.filter(Category.company_id == current_user.company_id)
+    elif company_id:
+        query = query.filter(Category.company_id == company_id)
+    categories = query.order_by(Category.name.asc()).all()
+    return [CategoryRead.model_validate(category) for category in categories]
+
+
+@app.post("/financial-goals", response_model=FinancialGoalRead)
+def create_financial_goal(
+    payload: FinancialGoalCreate,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> FinancialGoalRead:
+    ensure_company_access(payload.company_id, current_user)
+    ensure_company_exists(db, payload.company_id)
+    goal = FinancialGoal(**payload.model_dump())
+    db.add(goal)
+    db.commit()
+    db.refresh(goal)
+    return FinancialGoalRead.model_validate(goal)
+
+
+@app.get("/financial-goals", response_model=list[FinancialGoalProgress])
+def list_financial_goals(
+    company_id: Optional[int] = None,
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[FinancialGoalProgress]:
+    target_company_id = resolve_company_id(company_id, current_user)
+    ensure_company_exists(db, target_company_id)
+    goals = (
+        db.query(FinancialGoal)
+        .filter(FinancialGoal.company_id == target_company_id)
+        .order_by(FinancialGoal.period_end.asc())
+        .all()
+    )
+    progress_items = [calculate_goal_progress(db, goal) for goal in goals]
+    progress_items.sort(
+        key=lambda item: (
+            item.goal.archived,
+            item.status == GoalStatus.ACHIEVED,
+            item.goal.period_end,
+        )
+    )
+    return progress_items
+
+
+@app.get("/financial-goals/summary", response_model=FinancialGoalSummary)
+def summarize_financial_goals(
+    company_id: Optional[int] = None,
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> FinancialGoalSummary:
+    target_company_id = resolve_company_id(company_id, current_user)
+    ensure_company_exists(db, target_company_id)
+    goals = (
+        db.query(FinancialGoal)
+        .filter(FinancialGoal.company_id == target_company_id)
+        .order_by(FinancialGoal.period_end.asc())
+        .all()
+    )
+    progress_items = [calculate_goal_progress(db, goal) for goal in goals]
+    archived = sum(1 for goal in goals if goal.archived)
+    achieved = sum(1 for item in progress_items if item.status == GoalStatus.ACHIEVED)
+    in_progress = sum(1 for item in progress_items if item.status == GoalStatus.IN_PROGRESS)
+    missed = sum(1 for item in progress_items if item.status == GoalStatus.MISSED)
+    upcoming = [item for item in progress_items if not item.goal.archived]
+    upcoming.sort(
+        key=lambda item: (
+            item.status != GoalStatus.MISSED,
+            item.status == GoalStatus.ACHIEVED,
+            item.goal.period_end,
+        )
+    )
+    upcoming = upcoming[:3]
+    today = date.today()
+    future_candidates = [
+        item
+        for item in progress_items
+        if not item.goal.archived and item.goal.period_end >= today
+    ]
+    future_candidates.sort(key=lambda item: item.goal.period_end)
+    next_deadline = future_candidates[0].goal.period_end if future_candidates else None
+    return FinancialGoalSummary(
+        total=len(goals),
+        archived=archived,
+        achieved=achieved,
+        in_progress=in_progress,
+        missed=missed,
+        upcoming=upcoming,
+        next_deadline=next_deadline,
+    )
+
+
+@app.get("/financial-goals/{goal_id}", response_model=FinancialGoalRead)
+def get_financial_goal(
+    goal_id: int,
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> FinancialGoalRead:
+    goal = db.query(FinancialGoal).filter(FinancialGoal.id == goal_id).first()
+    if not goal:
+        raise HTTPException(status_code=404, detail="Meta não encontrada")
+    ensure_company_access(goal.company_id, current_user)
+    return FinancialGoalRead.model_validate(goal)
+
+
+@app.put("/financial-goals/{goal_id}", response_model=FinancialGoalRead)
+def update_financial_goal(
+    goal_id: int,
+    payload: FinancialGoalUpdate,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> FinancialGoalRead:
+    goal = db.query(FinancialGoal).filter(FinancialGoal.id == goal_id).first()
+    if not goal:
+        raise HTTPException(status_code=404, detail="Meta não encontrada")
+    ensure_company_access(goal.company_id, current_user)
+    update_data = payload.model_dump(exclude_unset=True)
+    new_period_start = update_data.get("period_start", goal.period_start)
+    new_period_end = update_data.get("period_end", goal.period_end)
+    if new_period_start and new_period_end and new_period_end < new_period_start:
+        raise HTTPException(
+            status_code=400,
+            detail="A data final deve ser posterior ou igual à data inicial da meta.",
+        )
+    if "target_amount" in update_data and update_data["target_amount"] is not None:
+        if update_data["target_amount"] <= 0:
+            raise HTTPException(status_code=400, detail="Informe um valor de meta maior que zero.")
+    for key, value in update_data.items():
+        setattr(goal, key, value)
+    db.commit()
+    db.refresh(goal)
+    return FinancialGoalRead.model_validate(goal)
+
+
+@app.delete("/financial-goals/{goal_id}", response_model=SimpleMessage)
+def delete_financial_goal(
+    goal_id: int,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> SimpleMessage:
+    goal = db.query(FinancialGoal).filter(FinancialGoal.id == goal_id).first()
+    if not goal:
+        raise HTTPException(status_code=404, detail="Meta não encontrada")
+    ensure_company_access(goal.company_id, current_user)
+    db.delete(goal)
+    db.commit()
+    return SimpleMessage(message="Meta removida com sucesso")
+
+
+@app.post("/tasks", response_model=ChecklistTaskRead)
+def create_task(
+    payload: ChecklistTaskCreate,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> ChecklistTaskRead:
+    ensure_company_access(payload.company_id, current_user)
+    ensure_company_exists(db, payload.company_id)
+    task = ChecklistTask(
+        company_id=payload.company_id,
+        title=payload.title,
+        description=payload.description,
+        status=payload.status or TaskStatus.OPEN,
+        due_date=payload.due_date,
+        assigned_to_id=payload.assigned_to_id,
+        created_by_id=current_user.id,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return serialize_task(task)
+
+
+@app.get("/tasks", response_model=list[ChecklistTaskRead])
+def list_tasks(
+    company_id: Optional[int] = None,
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[ChecklistTaskRead]:
+    target_company_id = resolve_company_id(company_id, current_user)
+    ensure_company_exists(db, target_company_id)
+    tasks = (
+        db.query(ChecklistTask)
+        .filter(ChecklistTask.company_id == target_company_id)
+        .all()
+    )
+    tasks.sort(
+        key=lambda task: (
+            task.status == TaskStatus.DONE,
+            task.due_date is None,
+            task.due_date or date.max,
+            task.created_at,
+        )
+    )
+    return [serialize_task(task) for task in tasks]
+
+
+@app.get("/tasks/summary", response_model=TaskSummary)
+def summarize_tasks(
+    company_id: Optional[int] = None,
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> TaskSummary:
+    target_company_id = resolve_company_id(company_id, current_user)
+    ensure_company_exists(db, target_company_id)
+    tasks = (
+        db.query(ChecklistTask)
+        .filter(ChecklistTask.company_id == target_company_id)
+        .all()
+    )
+    today = date.today()
+    soon_threshold = today + timedelta(days=7)
+    open_count = sum(1 for task in tasks if task.status == TaskStatus.OPEN)
+    in_progress_count = sum(1 for task in tasks if task.status == TaskStatus.IN_PROGRESS)
+    done_count = sum(1 for task in tasks if task.status == TaskStatus.DONE)
+    overdue_count = sum(
+        1
+        for task in tasks
+        if task.status != TaskStatus.DONE and task.due_date and task.due_date < today
+    )
+    due_today_count = sum(
+        1
+        for task in tasks
+        if task.status != TaskStatus.DONE and task.due_date == today
+    )
+    due_soon_count = sum(
+        1
+        for task in tasks
+        if task.status != TaskStatus.DONE
+        and task.due_date
+        and today < task.due_date <= soon_threshold
+    )
+    unassigned_count = sum(1 for task in tasks if task.assigned_to_id is None)
+    spotlight_candidates = [task for task in tasks if task.status != TaskStatus.DONE]
+    spotlight_candidates.sort(
+        key=lambda task: (
+            task.due_date is None,
+            task.due_date or date.max,
+            task.created_at,
+        )
+    )
+    spotlight = [serialize_task(task) for task in spotlight_candidates[:6]]
+    return TaskSummary(
+        total=len(tasks),
+        open=open_count,
+        in_progress=in_progress_count,
+        done=done_count,
+        overdue=overdue_count,
+        due_today=due_today_count,
+        due_soon=due_soon_count,
+        unassigned=unassigned_count,
+        spotlight=spotlight,
+    )
+
+
+@app.get("/tasks/{task_id}", response_model=ChecklistTaskRead)
+def get_task(
+    task_id: int,
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> ChecklistTaskRead:
+    task = db.query(ChecklistTask).filter(ChecklistTask.id == task_id).first()
+    if not task:
+        raise HTTPException(status_code=404, detail="Tarefa não encontrada")
+    ensure_company_access(task.company_id, current_user)
+    return serialize_task(task)
+
+
+@app.put("/tasks/{task_id}", response_model=ChecklistTaskRead)
+def update_task(
+    task_id: int,
+    payload: ChecklistTaskUpdate,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> ChecklistTaskRead:
+    task = db.query(ChecklistTask).filter(ChecklistTask.id == task_id).first()
+    if not task:
+        raise HTTPException(status_code=404, detail="Tarefa não encontrada")
+    ensure_company_access(task.company_id, current_user)
+    update_data = payload.model_dump(exclude_unset=True)
+    for key in ("title", "description", "due_date", "assigned_to_id"):
+        if key in update_data:
+            setattr(task, key, update_data[key])
+    if "status" in update_data and update_data["status"]:
+        new_status = update_data["status"]
+        task.status = new_status
+        if new_status == TaskStatus.DONE:
+            task.completed_at = datetime.utcnow()
+        else:
+            task.completed_at = None
+    db.commit()
+    db.refresh(task)
+    return serialize_task(task)
+
+
+@app.delete("/tasks/{task_id}", response_model=SimpleMessage)
+def delete_task(
+    task_id: int,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> SimpleMessage:
+    task = db.query(ChecklistTask).filter(ChecklistTask.id == task_id).first()
+    if not task:
+        raise HTTPException(status_code=404, detail="Tarefa não encontrada")
+    ensure_company_access(task.company_id, current_user)
+    db.delete(task)
+    db.commit()
+    return SimpleMessage(message="Tarefa removida com sucesso")
+
+
+@app.post("/transactions", response_model=TransactionRead)
+def create_transaction(
+    payload: TransactionCreate,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> TransactionRead:
+    if current_user.role == UserRole.CLIENT and payload.company_id != current_user.company_id:
+        raise HTTPException(status_code=403, detail="Lançamento deve pertencer à sua empresa")
+    transaction = Transaction(**payload.model_dump())
+    classify_transaction(db, transaction)
+    db.add(transaction)
+    db.commit()
+    db.refresh(transaction)
+    return TransactionRead.model_validate(transaction)
+
+
+@app.get("/transactions", response_model=list[TransactionRead])
+def list_transactions(
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    company_id: Optional[int] = None,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+) -> list[TransactionRead]:
+    query = db.query(Transaction)
+    if current_user.role == UserRole.CLIENT:
+        query = query.filter(Transaction.company_id == current_user.company_id)
+    elif company_id:
+        query = query.filter(Transaction.company_id == company_id)
+    if start_date:
+        query = query.filter(Transaction.date >= start_date)
+    if end_date:
+        query = query.filter(Transaction.date <= end_date)
+    transactions = query.order_by(Transaction.date.desc()).all()
+    return [TransactionRead.model_validate(transaction) for transaction in transactions]
+
+
+@app.put("/transactions/{transaction_id}", response_model=TransactionRead)
+def update_transaction(
+    transaction_id: int,
+    payload: TransactionUpdate,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> TransactionRead:
+    transaction = db.query(Transaction).filter(Transaction.id == transaction_id).first()
+    if not transaction:
+        raise HTTPException(status_code=404, detail="Lançamento não encontrado")
+    if current_user.role == UserRole.CLIENT and transaction.company_id != current_user.company_id:
+        raise HTTPException(status_code=403, detail="Você não pode editar este lançamento")
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        setattr(transaction, key, value)
+    transaction.auto_classified = False
+    classify_transaction(db, transaction)
+    db.commit()
+    db.refresh(transaction)
+    return TransactionRead.model_validate(transaction)
+
+
+@app.post("/transactions/import", response_model=UploadSummary)
+def import_transactions(
+    company_id: int,
+    file: UploadFile = File(...),
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> UploadSummary:
+    if current_user.role == UserRole.CLIENT and company_id != current_user.company_id:
+        raise HTTPException(status_code=403, detail="Importação deve pertencer à sua empresa")
+
+    records = parse_upload(file)
+    imported = 0
+    for data in records:
+        transaction = Transaction(
+            company_id=company_id,
+            date=data["date"],
+            description=data["description"],
+            amount=data["amount"],
+            transaction_type=data["transaction_type"],
+        )
+        classify_transaction(db, transaction)
+        db.add(transaction)
+        imported += 1
+    db.commit()
+
+    upload_log = UploadLog(
+        company_id=company_id,
+        filename=file.filename or "arquivo",
+        uploaded_by=current_user.id,
+        total_records=len(records),
+        notes="Importação concluída",
+    )
+    db.add(upload_log)
+    db.commit()
+
+    return UploadSummary(
+        filename=upload_log.filename,
+        total_records=upload_log.total_records,
+        imported=imported,
+        skipped=upload_log.total_records - imported,
+        notes=upload_log.notes,
+    )
+
+
+def build_cash_flow(db: Session, company_id: int, start_date: date, end_date: date) -> list[CashFlowEntry]:
+    cash_flow: list[CashFlowEntry] = []
+    current_month = date(start_date.year, start_date.month, 1)
+    balance = 0.0
+    while current_month <= end_date:
+        if current_month.month == 12:
+            next_month = date(current_month.year + 1, 1, 1)
+        else:
+            next_month = date(current_month.year, current_month.month + 1, 1)
+        period_start = max(start_date, current_month)
+        period_end = min(end_date, next_month - timedelta(days=1))
+        inflow = (
+            db.query(func.coalesce(func.sum(Transaction.amount), 0))
+            .filter(
+                Transaction.company_id == company_id,
+                Transaction.transaction_type == TransactionType.INFLOW,
+                Transaction.date >= period_start,
+                Transaction.date <= period_end,
+            )
+            .scalar()
+        )
+        outflow = (
+            db.query(func.coalesce(func.sum(Transaction.amount), 0))
+            .filter(
+                Transaction.company_id == company_id,
+                Transaction.transaction_type == TransactionType.OUTFLOW,
+                Transaction.date >= period_start,
+                Transaction.date <= period_end,
+            )
+            .scalar()
+        )
+        balance += float(inflow or 0) - float(outflow or 0)
+        cash_flow.append(
+            CashFlowEntry(
+                label=f"{current_month.month:02d}/{current_month.year}",
+                inflow=float(inflow or 0),
+                outflow=float(outflow or 0),
+                balance=balance,
+            )
+        )
+        current_month = next_month
+    return cash_flow
+
+
+def build_dre(db: Session, company_id: int, start_date: date, end_date: date) -> DRESummary:
+    revenue = (
+        db.query(func.coalesce(func.sum(Transaction.amount), 0))
+        .filter(
+            Transaction.company_id == company_id,
+            Transaction.transaction_type == TransactionType.INFLOW,
+            Transaction.date >= start_date,
+            Transaction.date <= end_date,
+        )
+        .scalar()
+    )
+    expenses = (
+        db.query(func.coalesce(func.sum(Transaction.amount), 0))
+        .filter(
+            Transaction.company_id == company_id,
+            Transaction.transaction_type == TransactionType.OUTFLOW,
+            Transaction.date >= start_date,
+            Transaction.date <= end_date,
+        )
+        .scalar()
+    )
+    revenue_value = float(revenue or 0)
+    expenses_value = float(expenses or 0)
+    result = revenue_value - expenses_value
+    if result > 0:
+        message = "A empresa está com saldo positivo no período."
+    elif result == 0:
+        message = "A empresa fechou o período empatada: o que entrou saiu."
+    else:
+        message = "Atenção: as saídas superaram as entradas. Revise seus gastos."
+    return DRESummary(
+        revenue=revenue_value,
+        expenses=expenses_value,
+        result=result,
+        message=message,
+    )
+
+
+def build_outstanding(
+    db: Session, company_id: int, start_date: date, end_date: date, txn_type: TransactionType
+) -> list[OutstandingEntry]:
+    transactions = (
+        db.query(Transaction)
+        .filter(
+            Transaction.company_id == company_id,
+            Transaction.transaction_type == txn_type,
+            Transaction.date >= start_date,
+            Transaction.date <= end_date,
+        )
+        .order_by(Transaction.date.asc())
+        .all()
+    )
+    status_label = "a receber" if txn_type == TransactionType.INFLOW else "a pagar"
+    return [
+        OutstandingEntry(
+            description=txn.description,
+            due_date=txn.date,
+            amount=float(txn.amount),
+            status=status_label,
+        )
+        for txn in transactions
+    ]
+
+
+def compute_financial_health(
+    db: Session, company_id: int, start_date: date, end_date: date
+) -> FinancialHealthReport:
+    cash_flow = build_cash_flow(db, company_id, start_date, end_date)
+    dre = build_dre(db, company_id, start_date, end_date)
+    payables = build_outstanding(db, company_id, start_date, end_date, TransactionType.OUTFLOW)
+    receivables = build_outstanding(db, company_id, start_date, end_date, TransactionType.INFLOW)
+
+    highlights = [
+        DashboardHighlight(
+            title="Saldo do período",
+            value=f"R$ {dre.result:,.2f}".replace(",", "X").replace(".", ",").replace("X", "."),
+            description="Mostra se você fechou o período no azul ou no vermelho.",
+        ),
+        DashboardHighlight(
+            title="Entradas",
+            value=f"R$ {dre.revenue:,.2f}".replace(",", "X").replace(".", ",").replace("X", "."),
+            description="Total de valores que chegaram na conta.",
+        ),
+        DashboardHighlight(
+            title="Saídas",
+            value=f"R$ {dre.expenses:,.2f}".replace(",", "X").replace(".", ",").replace("X", "."),
+            description="Quanto foi pago no período.",
+        ),
+    ]
+
+    period_label = f"De {start_date.strftime('%d/%m/%Y')} até {end_date.strftime('%d/%m/%Y')}"
+
+    return FinancialHealthReport(
+        period=period_label,
+        cash_flow=cash_flow,
+        dre=dre,
+        payables=payables,
+        receivables=receivables,
+        highlights=highlights,
+    )
+
+
+@app.get("/reports/financial-health", response_model=FinancialHealthReport)
+def financial_health(
+    company_id: int,
+    start_date: date,
+    end_date: date,
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> FinancialHealthReport:
+    if current_user.role == UserRole.CLIENT and company_id != current_user.company_id:
+        raise HTTPException(status_code=403, detail="Relatório restrito à sua empresa")
+
+    return compute_financial_health(db, company_id, start_date, end_date)
+
+
+@app.get("/reports/export")
+def export_report(
+    company_id: int,
+    start_date: date,
+    end_date: date,
+    report_type: str = "cashflow",
+    export_format: str = "xlsx",
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    if current_user.role == UserRole.CLIENT and company_id != current_user.company_id:
+        raise HTTPException(status_code=403, detail="Exportação restrita à sua empresa")
+
+    report = compute_financial_health(db, company_id, start_date, end_date)
+
+    if export_format == "xlsx":
+        output = io.BytesIO()
+        with pd.ExcelWriter(output, engine="openpyxl") as writer:
+            df_cash = pd.DataFrame([entry.model_dump() for entry in report.cash_flow])
+            df_cash.to_excel(writer, sheet_name="Fluxo de Caixa", index=False)
+            dre_df = pd.DataFrame([
+                {
+                    "Entradas": report.dre.revenue,
+                    "Saídas": report.dre.expenses,
+                    "Resultado": report.dre.result,
+                    "Mensagem": report.dre.message,
+                }
+            ])
+            dre_df.to_excel(writer, sheet_name="Resumo", index=False)
+            pd.DataFrame([entry.model_dump() for entry in report.payables]).to_excel(
+                writer, sheet_name="A Pagar", index=False
+            )
+            pd.DataFrame([entry.model_dump() for entry in report.receivables]).to_excel(
+                writer, sheet_name="A Receber", index=False
+            )
+        output.seek(0)
+        filename = f"relatorio_{report_type}_{start_date}_{end_date}.xlsx"
+        return StreamingResponse(
+            output,
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
+        )
+
+    if export_format == "pdf":
+        try:
+            from reportlab.lib.pagesizes import A4
+            from reportlab.lib.styles import getSampleStyleSheet
+            from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table
+        except ImportError as exc:  # pragma: no cover - guard if dependency missing
+            raise HTTPException(status_code=500, detail="Dependência de PDF ausente") from exc
+
+        buffer = io.BytesIO()
+        doc = SimpleDocTemplate(buffer, pagesize=A4)
+        styles = getSampleStyleSheet()
+        story = []
+        story.append(Paragraph("Relatório Financeiro", styles["Heading1"]))
+        story.append(Paragraph(report.period, styles["Normal"]))
+        story.append(Spacer(1, 12))
+        story.append(Paragraph("Resumo do período", styles["Heading2"]))
+        story.append(
+            Table(
+                [
+                    ["Entradas", f"R$ {report.dre.revenue:,.2f}"],
+                    ["Saídas", f"R$ {report.dre.expenses:,.2f}"],
+                    ["Resultado", f"R$ {report.dre.result:,.2f}"],
+                ]
+            )
+        )
+        story.append(Spacer(1, 12))
+        story.append(Paragraph(report.dre.message, styles["Italic"]))
+        story.append(Spacer(1, 12))
+        story.append(Paragraph("Principais destaques", styles["Heading2"]))
+        for highlight in report.highlights:
+            story.append(Paragraph(f"<b>{highlight.title}</b>: {highlight.description} - {highlight.value}", styles["Normal"]))
+        doc.build(story)
+        buffer.seek(0)
+        filename = f"relatorio_{report_type}_{start_date}_{end_date}.pdf"
+        return StreamingResponse(
+            buffer,
+            media_type="application/pdf",
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
+        )
+
+    raise HTTPException(status_code=400, detail="Formato de exportação não suportado")
+
+
+@app.get("/dashboard/overview", response_model=list[DashboardHighlight])
+def dashboard_overview(
+    current_user: CurrentUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[DashboardHighlight]:
+    if current_user.role == UserRole.CLIENT and not current_user.company_id:
+        return []
+
+    company_filter = current_user.company_id if current_user.role == UserRole.CLIENT else None
+
+    total_companies = (
+        db.query(func.count(Company.id))
+        if current_user.role != UserRole.CLIENT
+        else db.query(func.count(Company.id)).filter(Company.id == company_filter)
+    ).scalar()
+
+    total_users = (
+        db.query(func.count(User.id))
+        if current_user.role == UserRole.ADMIN
+        else db.query(func.count(User.id)).filter(User.company_id == company_filter)
+    ).scalar()
+
+    total_transactions = (
+        db.query(func.count(Transaction.id))
+        if not company_filter
+        else db.query(func.count(Transaction.id)).filter(Transaction.company_id == company_filter)
+    ).scalar()
+
+    highlights = [
+        DashboardHighlight(
+            title="Empresas acompanhadas" if current_user.role != UserRole.CLIENT else "Minha empresa",
+            value=str(total_companies or 0),
+            description="Quantidade de empresas atendidas pelo financeiro.",
+        ),
+        DashboardHighlight(
+            title="Pessoas com acesso",
+            value=str(total_users or 0),
+            description="Usuários com acesso ao painel.",
+        ),
+        DashboardHighlight(
+            title="Lançamentos registrados",
+            value=str(total_transactions or 0),
+            description="Soma de entradas e saídas cadastradas.",
+        ),
+    ]
+    return highlights
+
+
+@app.post("/integrations/nfse/{operation}", response_model=NFSeCallResponse)
+async def trigger_nfse_operation(
+    operation: str,
+    payload: NFSeCallRequest,
+    _: CurrentUser = Depends(require_role(UserRole.ADMIN, UserRole.STAFF)),
+) -> NFSeCallResponse:
+    config = _build_nfse_config(payload)
+    if config is None:
+        raise HTTPException(status_code=503, detail="Integração NFSe não está configurada.")
+
+    client = resolve_nfse_client(config, use_cache=not payload.has_overrides())
+
+    try:
+        output_xml = await client.call_operation(operation, payload.nfse_cabec_msg, payload.nfse_dados_msg)
+    except NFSeOperationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except NFSeConfigurationError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except NFSeServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return NFSeCallResponse(output_xml=output_xml)
+
+
+@app.post("/integrations/nfse/goiania/emissao", response_model=NFSeCallResponse)
+async def emitir_nfse_goiania(
+    payload: GoianiaNfseEmissionRequest,
+    current_user: CurrentUser = Depends(require_role(UserRole.ADMIN, UserRole.STAFF)),
+) -> NFSeCallResponse:
+    emission = payload.to_domain()
+    cabecalho, dados = build_goiania_payload(emission)
+    call_request = payload.to_call_request(cabecalho, dados)
+    config = _build_nfse_config(call_request)
+    if config is None:
+        raise HTTPException(status_code=503, detail="Integração NFSe não está configurada.")
+
+    client = resolve_nfse_client(config, use_cache=not call_request.has_overrides())
+
+    try:
+        output_xml = await client.call_operation("GerarNfse", call_request.nfse_cabec_msg, call_request.nfse_dados_msg)
+    except NFSeOperationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except NFSeConfigurationError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except NFSeServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return NFSeCallResponse(output_xml=output_xml)

--- a/bpo_app/models.py
+++ b/bpo_app/models.py
@@ -1,0 +1,142 @@
+from datetime import date, datetime
+from enum import Enum as PyEnum
+from typing import Optional
+
+from sqlalchemy import (
+    Boolean,
+    Date,
+    DateTime,
+    Enum as SQLAlchemyEnum,
+    Float,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .database import Base
+
+
+class Company(Base):
+    __tablename__ = "companies"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    trade_name: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    document: Mapped[Optional[str]] = mapped_column(String(32), unique=True, nullable=True)
+    notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    users: Mapped[list["User"]] = relationship("User", back_populates="company")
+    bank_accounts: Mapped[list["BankAccount"]] = relationship(
+        "BankAccount", back_populates="company", cascade="all, delete-orphan"
+    )
+    categories: Mapped[list["Category"]] = relationship(
+        "Category", back_populates="company", cascade="all, delete-orphan"
+    )
+    transactions: Mapped[list["Transaction"]] = relationship(
+        "Transaction", back_populates="company", cascade="all, delete-orphan"
+    )
+
+
+class UserRole(str, PyEnum):
+    ADMIN = "admin"
+    STAFF = "staff"
+    CLIENT = "client"
+
+
+class User(Base):
+    __tablename__ = "users"
+    __table_args__ = (UniqueConstraint("email", name="uq_users_email"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    full_name: Mapped[str] = mapped_column(String(200), nullable=False)
+    email: Mapped[str] = mapped_column(String(200), nullable=False)
+    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    role: Mapped[UserRole] = mapped_column(SQLAlchemyEnum(UserRole), nullable=False)
+    company_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("companies.id"))
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    company: Mapped[Optional[Company]] = relationship("Company", back_populates="users")
+
+
+class BankAccount(Base):
+    __tablename__ = "bank_accounts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    company_id: Mapped[int] = mapped_column(Integer, ForeignKey("companies.id"), index=True)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    bank_name: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
+    account_number: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
+    initial_balance: Mapped[float] = mapped_column(Float, default=0.0)
+
+    company: Mapped[Company] = relationship("Company", back_populates="bank_accounts")
+    transactions: Mapped[list["Transaction"]] = relationship(
+        "Transaction", back_populates="bank_account"
+    )
+
+
+class Category(Base):
+    __tablename__ = "categories"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    company_id: Mapped[int] = mapped_column(Integer, ForeignKey("companies.id"), index=True)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    keywords: Mapped[Optional[str]] = mapped_column(String(400), nullable=True)
+    color: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+
+    company: Mapped[Company] = relationship("Company", back_populates="categories")
+    transactions: Mapped[list["Transaction"]] = relationship(
+        "Transaction", back_populates="category"
+    )
+
+
+class TransactionType(str, PyEnum):
+    INFLOW = "inflow"
+    OUTFLOW = "outflow"
+
+
+class Transaction(Base):
+    __tablename__ = "transactions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    company_id: Mapped[int] = mapped_column(Integer, ForeignKey("companies.id"), index=True)
+    bank_account_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("bank_accounts.id"), nullable=True
+    )
+    date: Mapped[date] = mapped_column(Date, nullable=False)
+    description: Mapped[str] = mapped_column(String(255), nullable=False)
+    amount: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
+    transaction_type: Mapped[TransactionType] = mapped_column(
+        SQLAlchemyEnum(TransactionType), nullable=False
+    )
+    category_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("categories.id"))
+    notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    auto_classified: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    company: Mapped[Company] = relationship("Company", back_populates="transactions")
+    bank_account: Mapped[Optional[BankAccount]] = relationship(
+        "BankAccount", back_populates="transactions"
+    )
+    category: Mapped[Optional[Category]] = relationship(
+        "Category", back_populates="transactions"
+    )
+
+
+class UploadLog(Base):
+    __tablename__ = "upload_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    company_id: Mapped[int] = mapped_column(Integer, ForeignKey("companies.id"))
+    filename: Mapped[str] = mapped_column(String(200), nullable=False)
+    uploaded_by: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"))
+    total_records: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    company: Mapped[Company] = relationship("Company")

--- a/bpo_app/nfse_client.py
+++ b/bpo_app/nfse_client.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+from requests import Session
+from zeep import Client, Settings as ZeepSettings
+from zeep.exceptions import Fault
+from zeep.transports import Transport
+
+NFSE_NAMESPACE = "{http://nfse.abrasf.org.br}nfseSOAP"
+
+ALLOWED_OPERATIONS = {
+    "CancelarNfse",
+    "ConsultarLoteRps",
+    "ConsultarNfseServicoPrestado",
+    "ConsultarNfseServicoTomado",
+    "ConsultarNfsePorFaixa",
+    "ConsultarNfsePorRps",
+    "RecepcionarLoteRps",
+    "GerarNfse",
+    "SubstituirNfse",
+    "RecepcionarLoteRpsSincrono",
+    "ConsultarUrlNfse",
+    "ConsultarDadosCadastrais",
+    "ConsultarRpsDisponivel",
+}
+
+
+class NFSeError(Exception):
+    """Base error for NFSe integration."""
+
+
+class NFSeConfigurationError(NFSeError):
+    """Raised when the NFSe client is not properly configured."""
+
+
+class NFSeOperationError(NFSeError):
+    """Raised when an invalid request is made to the NFSe service."""
+
+
+class NFSeServiceError(NFSeError):
+    """Raised when the remote NFSe service returns an error."""
+
+
+@dataclass(eq=True)
+class NFSeClientConfig:
+    wsdl_url: str
+    service_url: Optional[str] = None
+    timeout: int = 30
+    verify_ssl: bool = True
+
+    def __post_init__(self) -> None:
+        self.wsdl_url = self.wsdl_url.strip()
+        if not self.wsdl_url:
+            raise ValueError("O endereço WSDL do serviço NFSe é obrigatório.")
+        if self.service_url:
+            cleaned = self.service_url.strip()
+            if cleaned:
+                self.service_url = _normalize_address(self.wsdl_url, cleaned)
+            else:
+                self.service_url = None
+        if self.timeout <= 0:
+            self.timeout = 30
+
+
+class NFSeClient:
+    def __init__(self, config: NFSeClientConfig):
+        self.config = config
+        self._client: Optional[Client] = None
+
+    def _create_transport(self) -> Transport:
+        session = Session()
+        session.verify = self.config.verify_ssl
+        return Transport(session=session, timeout=self.config.timeout)
+
+    def _get_client(self) -> Client:
+        if self._client is None:
+            transport = self._create_transport()
+            zeep_settings = ZeepSettings(strict=False, xml_huge_tree=True)
+            self._client = Client(self.config.wsdl_url, transport=transport, settings=zeep_settings)
+        return self._client
+
+    def _get_service(self):
+        client = self._get_client()
+        address = self.config.service_url or client.service._binding_options.get("address")
+        normalized = _normalize_address(self.config.wsdl_url, address)
+        return client.create_service(NFSE_NAMESPACE, normalized)
+
+    async def call_operation(self, operation: str, cabec_msg: str, dados_msg: str) -> str:
+        op_name = (operation or "").strip()
+        if op_name not in ALLOWED_OPERATIONS:
+            raise NFSeOperationError(f"Operação NFSe desconhecida: {operation}")
+
+        cabec = (cabec_msg or "").strip()
+        dados = (dados_msg or "").strip()
+        if not cabec or not dados:
+            raise NFSeOperationError("As mensagens nfseCabecMsg e nfseDadosMsg são obrigatórias.")
+
+        service = self._get_service()
+        method = getattr(service, op_name, None)
+        if method is None:
+            raise NFSeOperationError(f"Operação NFSe não suportada pelo serviço: {operation}")
+
+        try:
+            response = await asyncio.to_thread(
+                method,
+                nfseCabecMsg=cabec,
+                nfseDadosMsg=dados,
+            )
+        except Fault as exc:
+            raise NFSeServiceError(str(exc)) from exc
+        except Exception as exc:  # pragma: no cover - proteção adicional
+            raise NFSeServiceError("Falha ao comunicar com o serviço NFSe.") from exc
+
+        return _extract_output_xml(response)
+
+
+def _extract_output_xml(response: object) -> str:
+    if response is None:
+        return ""
+    if isinstance(response, dict):
+        value = response.get("outputXML") or response.get("OutputXML")
+        if value is not None:
+            return str(value)
+    output = getattr(response, "outputXML", None) or getattr(response, "OutputXML", None)
+    if output is not None:
+        return str(output)
+    return str(response)
+
+
+def _normalize_address(wsdl_url: str, address: Optional[str]) -> str:
+    if not address:
+        raise NFSeConfigurationError("Endereço do serviço NFSe não foi informado no WSDL.")
+    cleaned = address.strip()
+    if not cleaned:
+        raise NFSeConfigurationError("Endereço do serviço NFSe não foi informado no WSDL.")
+    parsed = urlparse(cleaned)
+    if parsed.scheme:
+        return cleaned
+    return urljoin(wsdl_url, cleaned)
+
+
+__all__ = [
+    "ALLOWED_OPERATIONS",
+    "NFSE_NAMESPACE",
+    "NFSeClient",
+    "NFSeClientConfig",
+    "NFSeConfigurationError",
+    "NFSeOperationError",
+    "NFSeServiceError",
+]

--- a/bpo_app/nfse_goiania.py
+++ b/bpo_app/nfse_goiania.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Optional
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+ABRASF_NAMESPACE = "http://www.abrasf.org.br/nfse.xsd"
+GOIANIA_MUNICIPAL_CODE = "5208707"
+
+
+def _ensure_decimal(value: Decimal | float | int | str) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def _format_decimal(value: Decimal | float | int | str) -> str:
+    dec = _ensure_decimal(value).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    return f"{dec:.2f}"
+
+
+def _only_digits(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    return "".join(ch for ch in value if ch.isdigit()) or None
+
+
+def _serialize(element: Element) -> str:
+    xml_bytes = tostring(element, encoding="utf-8", xml_declaration=False)
+    return xml_bytes.decode("utf-8")
+
+
+@dataclass(slots=True)
+class GoianiaPrestador:
+    cnpj: str
+    inscricao_municipal: str
+
+
+@dataclass(slots=True)
+class GoianiaTomadorEndereco:
+    logradouro: str
+    numero: str
+    bairro: str
+    codigo_municipio: str = GOIANIA_MUNICIPAL_CODE
+    uf: str = "GO"
+    cep: Optional[str] = None
+    complemento: Optional[str] = None
+
+
+@dataclass(slots=True)
+class GoianiaTomador:
+    razao_social: str
+    cpf_cnpj: str
+    inscricao_municipal: Optional[str]
+    email: Optional[str]
+    telefone: Optional[str]
+    endereco: GoianiaTomadorEndereco
+
+
+@dataclass(slots=True)
+class GoianiaServicoValores:
+    valor_servicos: Decimal
+    valor_deducoes: Decimal = Decimal("0")
+    valor_pis: Decimal = Decimal("0")
+    valor_cofins: Decimal = Decimal("0")
+    valor_inss: Decimal = Decimal("0")
+    valor_ir: Decimal = Decimal("0")
+    valor_csll: Decimal = Decimal("0")
+    outros_retencoes: Decimal = Decimal("0")
+    iss_retido: int = 2
+    valor_iss: Optional[Decimal] = None
+    valor_iss_retido: Optional[Decimal] = None
+    aliquota: Optional[Decimal] = None
+    desconto_condicionado: Optional[Decimal] = None
+    desconto_incondicionado: Optional[Decimal] = None
+
+
+@dataclass(slots=True)
+class GoianiaServico:
+    valores: GoianiaServicoValores
+    item_lista_servico: str
+    codigo_tributacao_municipio: str
+    discriminacao: str
+    codigo_municipio: str = GOIANIA_MUNICIPAL_CODE
+
+
+@dataclass(slots=True)
+class GoianiaNfseEmission:
+    numero_lote: str
+    numero_rps: str
+    serie_rps: str
+    tipo_rps: int
+    data_emissao: datetime
+    natureza_operacao: int
+    regime_especial_tributacao: Optional[int]
+    optante_simples: int
+    incentivador_cultural: int
+    status_rps: int
+    prestador: GoianiaPrestador
+    servico: GoianiaServico
+    tomador: GoianiaTomador
+
+
+def build_goiania_header(versao: str = "2.03") -> str:
+    root = Element(f"{{{ABRASF_NAMESPACE}}}cabecalho", versao=versao)
+    SubElement(root, "VersaoDados").text = versao
+    return _serialize(root)
+
+
+def _append_optional(parent: Element, tag: str, value: Optional[str]) -> None:
+    if value is None:
+        return
+    SubElement(parent, tag).text = value
+
+
+def _append_decimal(parent: Element, tag: str, value: Optional[Decimal]) -> None:
+    if value is None:
+        return
+    SubElement(parent, tag).text = _format_decimal(value)
+
+
+def build_goiania_gerar_nfse(emission: GoianiaNfseEmission) -> str:
+    root = Element(f"{{{ABRASF_NAMESPACE}}}GerarNfseEnvio")
+
+    lote = SubElement(root, "LoteRps")
+    SubElement(lote, "NumeroLote").text = emission.numero_lote
+    SubElement(lote, "Cnpj").text = _only_digits(emission.prestador.cnpj) or emission.prestador.cnpj
+    SubElement(lote, "InscricaoMunicipal").text = _only_digits(emission.prestador.inscricao_municipal)
+    SubElement(lote, "QuantidadeRps").text = "1"
+
+    lista_rps = SubElement(lote, "ListaRps")
+    rps = SubElement(lista_rps, "Rps")
+    inf_rps = SubElement(rps, "InfRps", Id=f"RPS{emission.numero_rps}")
+
+    identificacao = SubElement(inf_rps, "IdentificacaoRps")
+    SubElement(identificacao, "Numero").text = emission.numero_rps
+    SubElement(identificacao, "Serie").text = emission.serie_rps
+    SubElement(identificacao, "Tipo").text = str(emission.tipo_rps)
+
+    SubElement(inf_rps, "DataEmissao").text = emission.data_emissao.strftime("%Y-%m-%dT%H:%M:%S")
+    SubElement(inf_rps, "NaturezaOperacao").text = str(emission.natureza_operacao)
+    if emission.regime_especial_tributacao is not None:
+        SubElement(inf_rps, "RegimeEspecialTributacao").text = str(emission.regime_especial_tributacao)
+    SubElement(inf_rps, "OptanteSimplesNacional").text = str(emission.optante_simples)
+    SubElement(inf_rps, "IncentivadorCultural").text = str(emission.incentivador_cultural)
+    SubElement(inf_rps, "Status").text = str(emission.status_rps)
+
+    servico = SubElement(inf_rps, "Servico")
+    valores = SubElement(servico, "Valores")
+    SubElement(valores, "ValorServicos").text = _format_decimal(emission.servico.valores.valor_servicos)
+    _append_decimal(valores, "ValorDeducoes", emission.servico.valores.valor_deducoes)
+    _append_decimal(valores, "ValorPis", emission.servico.valores.valor_pis)
+    _append_decimal(valores, "ValorCofins", emission.servico.valores.valor_cofins)
+    _append_decimal(valores, "ValorInss", emission.servico.valores.valor_inss)
+    _append_decimal(valores, "ValorIr", emission.servico.valores.valor_ir)
+    _append_decimal(valores, "ValorCsll", emission.servico.valores.valor_csll)
+    _append_decimal(valores, "OutrasRetencoes", emission.servico.valores.outros_retencoes)
+    SubElement(valores, "IssRetido").text = str(emission.servico.valores.iss_retido)
+    _append_decimal(valores, "ValorIss", emission.servico.valores.valor_iss)
+    _append_decimal(valores, "ValorIssRetido", emission.servico.valores.valor_iss_retido)
+    _append_decimal(valores, "Aliquota", emission.servico.valores.aliquota)
+    _append_decimal(valores, "DescontoCondicionado", emission.servico.valores.desconto_condicionado)
+    _append_decimal(valores, "DescontoIncondicionado", emission.servico.valores.desconto_incondicionado)
+
+    SubElement(servico, "ItemListaServico").text = emission.servico.item_lista_servico
+    SubElement(servico, "CodigoTributacaoMunicipio").text = emission.servico.codigo_tributacao_municipio
+    SubElement(servico, "Discriminacao").text = emission.servico.discriminacao
+    SubElement(servico, "CodigoMunicipio").text = emission.servico.codigo_municipio
+
+    prestador = SubElement(inf_rps, "Prestador")
+    SubElement(prestador, "Cnpj").text = _only_digits(emission.prestador.cnpj) or emission.prestador.cnpj
+    SubElement(prestador, "InscricaoMunicipal").text = _only_digits(emission.prestador.inscricao_municipal)
+
+    tomador = SubElement(inf_rps, "Tomador")
+    identificacao_tomador = SubElement(tomador, "IdentificacaoTomador")
+    cpf_cnpj = SubElement(identificacao_tomador, "CpfCnpj")
+    digits_tomador = _only_digits(emission.tomador.cpf_cnpj)
+    if digits_tomador and len(digits_tomador) == 11:
+        SubElement(cpf_cnpj, "Cpf").text = digits_tomador
+    else:
+        SubElement(cpf_cnpj, "Cnpj").text = digits_tomador or emission.tomador.cpf_cnpj
+    _append_optional(identificacao_tomador, "InscricaoMunicipal", _only_digits(emission.tomador.inscricao_municipal))
+
+    SubElement(tomador, "RazaoSocial").text = emission.tomador.razao_social
+    endereco = SubElement(tomador, "Endereco")
+    SubElement(endereco, "Endereco").text = emission.tomador.endereco.logradouro
+    SubElement(endereco, "Numero").text = emission.tomador.endereco.numero
+    _append_optional(endereco, "Complemento", emission.tomador.endereco.complemento)
+    SubElement(endereco, "Bairro").text = emission.tomador.endereco.bairro
+    SubElement(endereco, "CodigoMunicipio").text = emission.tomador.endereco.codigo_municipio
+    SubElement(endereco, "Uf").text = emission.tomador.endereco.uf
+    _append_optional(endereco, "Cep", _only_digits(emission.tomador.endereco.cep))
+
+    contato = SubElement(tomador, "Contato")
+    _append_optional(contato, "Telefone", _only_digits(emission.tomador.telefone))
+    _append_optional(contato, "Email", emission.tomador.email)
+
+    return _serialize(root)
+
+
+def build_goiania_payload(emission: GoianiaNfseEmission, versao: str = "2.03") -> tuple[str, str]:
+    cabecalho = build_goiania_header(versao=versao)
+    dados = build_goiania_gerar_nfse(emission)
+    return cabecalho, dados
+
+
+__all__ = [
+    "ABRASF_NAMESPACE",
+    "GoianiaNfseEmission",
+    "GoianiaPrestador",
+    "GoianiaServico",
+    "GoianiaServicoValores",
+    "GoianiaTomador",
+    "GoianiaTomadorEndereco",
+    "build_goiania_payload",
+]

--- a/bpo_app/schemas.py
+++ b/bpo_app/schemas.py
@@ -1,0 +1,548 @@
+from datetime import date, datetime
+from enum import Enum
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, FieldValidationInfo, field_validator
+
+from .models import TaskStatus, TransactionType, UserRole
+from .nfse_goiania import (
+    GoianiaNfseEmission,
+    GoianiaPrestador,
+    GoianiaServico,
+    GoianiaServicoValores,
+    GoianiaTomador,
+    GoianiaTomadorEndereco,
+)
+
+
+class CompanyBase(BaseModel):
+    name: str = Field(..., description="Nome da empresa")
+    trade_name: Optional[str] = Field(None, description="Nome fantasia")
+    document: Optional[str] = Field(None, description="CNPJ ou CPF")
+    notes: Optional[str] = Field(None, description="Observações internas")
+
+
+class CompanyCreate(CompanyBase):
+    pass
+
+
+class CompanyUpdate(BaseModel):
+    name: Optional[str] = None
+    trade_name: Optional[str] = None
+    document: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class CompanyRead(CompanyBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserBase(BaseModel):
+    full_name: str
+    email: EmailStr
+    role: UserRole
+    company_id: Optional[int] = None
+    is_active: bool = True
+
+
+class UserCreate(UserBase):
+    password: str = Field(..., min_length=6)
+
+
+class UserUpdate(BaseModel):
+    full_name: Optional[str] = None
+    email: Optional[EmailStr] = None
+    role: Optional[UserRole] = None
+    company_id: Optional[int] = None
+    is_active: Optional[bool] = None
+    password: Optional[str] = Field(None, min_length=6)
+
+
+class UserRead(UserBase):
+    id: int
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class BankAccountBase(BaseModel):
+    name: str
+    bank_name: Optional[str] = None
+    account_number: Optional[str] = None
+    initial_balance: float = 0.0
+
+
+class BankAccountCreate(BankAccountBase):
+    company_id: int
+
+
+class BankAccountUpdate(BaseModel):
+    name: Optional[str] = None
+    bank_name: Optional[str] = None
+    account_number: Optional[str] = None
+    initial_balance: Optional[float] = None
+
+
+class BankAccountRead(BankAccountBase):
+    id: int
+    company_id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CategoryBase(BaseModel):
+    name: str
+    keywords: Optional[str] = Field(
+        None,
+        description="Palavras-chave separadas por vírgula para classificação automática",
+    )
+    color: Optional[str] = Field(None, description="Cor usada na interface (hexadecimal)")
+
+
+class CategoryCreate(CategoryBase):
+    company_id: int
+
+
+class CategoryUpdate(BaseModel):
+    name: Optional[str] = None
+    keywords: Optional[str] = None
+    color: Optional[str] = None
+
+
+class CategoryRead(CategoryBase):
+    id: int
+    company_id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class GoalStatus(str, Enum):
+    IN_PROGRESS = "in_progress"
+    ACHIEVED = "achieved"
+    MISSED = "missed"
+
+
+class FinancialGoalBase(BaseModel):
+    name: str = Field(..., min_length=2)
+    description: Optional[str] = Field(None, max_length=2000)
+    target_amount: float = Field(..., gt=0)
+    direction: TransactionType
+    period_start: date
+    period_end: date
+    archived: bool = False
+
+    @field_validator("period_end")
+    @classmethod
+    def validate_period(cls, value: date, info: FieldValidationInfo) -> date:
+        start = info.data.get("period_start")
+        if isinstance(start, date) and value < start:
+            raise ValueError("A data final deve ser posterior ou igual à data inicial da meta.")
+        return value
+
+
+class FinancialGoalCreate(FinancialGoalBase):
+    company_id: int
+
+
+class FinancialGoalUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=2)
+    description: Optional[str] = Field(None, max_length=2000)
+    target_amount: Optional[float] = Field(None, gt=0)
+    direction: Optional[TransactionType] = None
+    period_start: Optional[date] = None
+    period_end: Optional[date] = None
+    archived: Optional[bool] = None
+
+    @field_validator("period_end")
+    @classmethod
+    def validate_period_end(cls, value: Optional[date], info: FieldValidationInfo) -> Optional[date]:
+        start = info.data.get("period_start")
+        if isinstance(start, date) and value is not None and value < start:
+            raise ValueError("A data final deve ser posterior ou igual à data inicial da meta.")
+        return value
+
+
+class FinancialGoalRead(FinancialGoalBase):
+    id: int
+    company_id: int
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FinancialGoalProgress(BaseModel):
+    goal: FinancialGoalRead
+    actual_amount: float
+    remaining_amount: float
+    progress_percentage: float
+    status: GoalStatus
+    message: str
+
+
+class FinancialGoalSummary(BaseModel):
+    total: int = 0
+    archived: int = 0
+    achieved: int = 0
+    in_progress: int = 0
+    missed: int = 0
+    upcoming: list[FinancialGoalProgress] = Field(default_factory=list)
+    next_deadline: Optional[date] = None
+
+
+class TaskUserSummary(BaseModel):
+    id: int
+    full_name: str
+    email: EmailStr
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ChecklistTaskBase(BaseModel):
+    title: str = Field(..., min_length=2)
+    description: Optional[str] = Field(None, max_length=4000)
+    due_date: Optional[date] = None
+    status: TaskStatus = TaskStatus.OPEN
+    assigned_to_id: Optional[int] = None
+
+
+class ChecklistTaskCreate(ChecklistTaskBase):
+    company_id: int
+
+
+class ChecklistTaskUpdate(BaseModel):
+    title: Optional[str] = Field(None, min_length=2)
+    description: Optional[str] = Field(None, max_length=4000)
+    due_date: Optional[date] = None
+    status: Optional[TaskStatus] = None
+    assigned_to_id: Optional[int] = Field(default=None)
+
+
+class ChecklistTaskRead(ChecklistTaskBase):
+    id: int
+    company_id: int
+    created_by_id: Optional[int] = None
+    created_at: datetime
+    updated_at: datetime
+    completed_at: Optional[datetime] = None
+    assigned_to: Optional[TaskUserSummary] = None
+    created_by: Optional[TaskUserSummary] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TaskSummary(BaseModel):
+    total: int = 0
+    open: int = 0
+    in_progress: int = 0
+    done: int = 0
+    overdue: int = 0
+    due_today: int = 0
+    due_soon: int = 0
+    unassigned: int = 0
+    spotlight: list[ChecklistTaskRead] = Field(default_factory=list)
+
+
+class TransactionBase(BaseModel):
+    company_id: int
+    bank_account_id: Optional[int] = None
+    date: date
+    description: str
+    amount: float
+    transaction_type: TransactionType
+    category_id: Optional[int] = None
+    notes: Optional[str] = None
+
+
+class TransactionCreate(TransactionBase):
+    pass
+
+
+class TransactionUpdate(BaseModel):
+    bank_account_id: Optional[int] = None
+    date: Optional[date] = None
+    description: Optional[str] = None
+    amount: Optional[float] = None
+    transaction_type: Optional[TransactionType] = None
+    category_id: Optional[int] = None
+    notes: Optional[str] = None
+
+
+class TransactionRead(TransactionBase):
+    id: int
+    auto_classified: bool
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UploadSummary(BaseModel):
+    filename: str
+    total_records: int
+    imported: int
+    skipped: int
+    notes: Optional[str] = None
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class LoginRequest(BaseModel):
+    email: str = Field(..., min_length=3, description="Endereço de e-mail do usuário")
+    password: str = Field(..., min_length=1, description="Senha de acesso")
+
+    @field_validator("email")
+    @classmethod
+    def normalize_email(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Informe o e-mail do usuário.")
+        return cleaned.lower()
+
+
+class DashboardHighlight(BaseModel):
+    title: str
+    value: str
+    description: str
+
+
+class CashFlowEntry(BaseModel):
+    label: str
+    inflow: float
+    outflow: float
+    balance: float
+
+
+class DRESummary(BaseModel):
+    revenue: float
+    expenses: float
+    result: float
+    message: str
+
+
+class OutstandingEntry(BaseModel):
+    description: str
+    due_date: date
+    amount: float
+    status: str
+
+
+class FinancialHealthReport(BaseModel):
+    period: str
+    cash_flow: list[CashFlowEntry]
+    dre: DRESummary
+    payables: list[OutstandingEntry]
+    receivables: list[OutstandingEntry]
+    highlights: list[DashboardHighlight]
+
+
+class CurrentUser(BaseModel):
+    id: int
+    full_name: str
+    email: EmailStr
+    role: UserRole
+    company_id: Optional[int] = None
+
+
+class SimpleMessage(BaseModel):
+    message: str
+
+
+class NFSeOverrides(BaseModel):
+    wsdl_url: Optional[str] = Field(
+        None,
+        description="URL completa do WSDL para sobrescrever a configuração padrão (opcional)",
+    )
+    service_url: Optional[str] = Field(
+        None,
+        description="Endpoint completo do serviço SOAP quando diferente do WSDL (opcional)",
+    )
+    timeout: Optional[int] = Field(
+        None,
+        ge=1,
+        le=600,
+        description="Tempo máximo de espera pela resposta do serviço, em segundos (opcional)",
+    )
+    verify_ssl: Optional[bool] = Field(
+        None,
+        description="Define se a verificação de certificado SSL deve ser forçada ou não (opcional)",
+    )
+
+    @field_validator("wsdl_url", "service_url")
+    @classmethod
+    def normalize_optional_urls(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+    def has_overrides(self) -> bool:
+        return any(value is not None for value in (self.wsdl_url, self.service_url, self.timeout, self.verify_ssl))
+
+
+class NFSeCallRequest(NFSeOverrides):
+    nfse_cabec_msg: str = Field(..., min_length=1, description="XML do cabeçalho da requisição NFSe")
+    nfse_dados_msg: str = Field(..., min_length=1, description="XML com os dados da requisição NFSe")
+
+    @field_validator("nfse_cabec_msg", "nfse_dados_msg")
+    @classmethod
+    def ensure_not_blank(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Informe o conteúdo XML da mensagem NFSe.")
+        return cleaned
+
+
+class NFSeCallResponse(BaseModel):
+    output_xml: str = Field(..., description="XML devolvido pelo serviço NFSe")
+
+
+class GoianiaNfsePrestador(BaseModel):
+    cnpj: str = Field(..., min_length=1, description="CNPJ do prestador")
+    inscricao_municipal: str = Field(..., min_length=1, description="Inscrição municipal do prestador")
+
+    @field_validator("cnpj", "inscricao_municipal")
+    @classmethod
+    def remove_spaces(cls, value: str) -> str:
+        return value.strip()
+
+
+class GoianiaNfseEndereco(BaseModel):
+    logradouro: str
+    numero: str
+    bairro: str
+    codigo_municipio: str = Field("5208707", description="Código IBGE do município")
+    uf: str = Field("GO", min_length=2, max_length=2)
+    cep: Optional[str] = None
+    complemento: Optional[str] = None
+
+    @field_validator("logradouro", "numero", "bairro", "codigo_municipio", "uf")
+    @classmethod
+    def ensure_not_empty(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Informe o endereço completo do tomador.")
+        return cleaned
+
+
+class GoianiaNfseTomador(BaseModel):
+    razao_social: str
+    cpf_cnpj: str
+    inscricao_municipal: Optional[str] = None
+    email: Optional[EmailStr] = None
+    telefone: Optional[str] = None
+    endereco: GoianiaNfseEndereco
+
+    @field_validator("razao_social", "cpf_cnpj")
+    @classmethod
+    def sanitize_text(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Informe os dados do tomador.")
+        return cleaned
+
+
+class GoianiaNfseServicoValoresModel(BaseModel):
+    valor_servicos: Decimal = Field(..., description="Valor bruto dos serviços")
+    valor_deducoes: Decimal = Decimal("0")
+    valor_pis: Decimal = Decimal("0")
+    valor_cofins: Decimal = Decimal("0")
+    valor_inss: Decimal = Decimal("0")
+    valor_ir: Decimal = Decimal("0")
+    valor_csll: Decimal = Decimal("0")
+    outros_retencoes: Decimal = Decimal("0")
+    iss_retido: int = Field(2, ge=1, le=2)
+    valor_iss: Optional[Decimal] = None
+    valor_iss_retido: Optional[Decimal] = None
+    aliquota: Optional[Decimal] = None
+    desconto_condicionado: Optional[Decimal] = None
+    desconto_incondicionado: Optional[Decimal] = None
+
+
+class GoianiaNfseServicoModel(BaseModel):
+    item_lista_servico: str
+    codigo_tributacao_municipio: str
+    discriminacao: str
+    codigo_municipio: str = Field("5208707", description="Código do município da prestação")
+    valores: GoianiaNfseServicoValoresModel
+
+    @field_validator("item_lista_servico", "codigo_tributacao_municipio", "discriminacao")
+    @classmethod
+    def ensure_required(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Informe os dados do serviço.")
+        return cleaned
+
+
+class GoianiaNfseEmissionRequest(NFSeOverrides):
+    numero_lote: str = Field(..., description="Número do lote a ser enviado")
+    numero_rps: str = Field(..., description="Número do RPS")
+    serie_rps: str = Field(..., description="Série do RPS")
+    tipo_rps: int = Field(1, ge=1, le=3)
+    data_emissao: datetime = Field(..., description="Data e hora da emissão do RPS")
+    natureza_operacao: int = Field(1, ge=1, le=6)
+    regime_especial_tributacao: Optional[int] = Field(None, ge=1, le=6)
+    optante_simples: int = Field(1, ge=1, le=2)
+    incentivador_cultural: int = Field(2, ge=1, le=2)
+    status_rps: int = Field(1, ge=1, le=2)
+    prestador: GoianiaNfsePrestador
+    servico: GoianiaNfseServicoModel
+    tomador: GoianiaNfseTomador
+
+    @field_validator("numero_lote", "numero_rps", "serie_rps")
+    @classmethod
+    def ensure_identifiers(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Informe os identificadores do RPS.")
+        return cleaned
+
+    def to_domain(self) -> GoianiaNfseEmission:
+        valores = GoianiaServicoValores(**self.servico.valores.model_dump())
+        servico = GoianiaServico(
+            valores=valores,
+            item_lista_servico=self.servico.item_lista_servico,
+            codigo_tributacao_municipio=self.servico.codigo_tributacao_municipio,
+            discriminacao=self.servico.discriminacao,
+            codigo_municipio=self.servico.codigo_municipio,
+        )
+        prestador = GoianiaPrestador(**self.prestador.model_dump())
+        endereco = GoianiaTomadorEndereco(**self.tomador.endereco.model_dump())
+        tomador = GoianiaTomador(
+            razao_social=self.tomador.razao_social,
+            cpf_cnpj=self.tomador.cpf_cnpj,
+            inscricao_municipal=self.tomador.inscricao_municipal,
+            email=self.tomador.email,
+            telefone=self.tomador.telefone,
+            endereco=endereco,
+        )
+        return GoianiaNfseEmission(
+            numero_lote=self.numero_lote,
+            numero_rps=self.numero_rps,
+            serie_rps=self.serie_rps,
+            tipo_rps=self.tipo_rps,
+            data_emissao=self.data_emissao,
+            natureza_operacao=self.natureza_operacao,
+            regime_especial_tributacao=self.regime_especial_tributacao,
+            optante_simples=self.optante_simples,
+            incentivador_cultural=self.incentivador_cultural,
+            status_rps=self.status_rps,
+            prestador=prestador,
+            servico=servico,
+            tomador=tomador,
+        )
+
+    def to_call_request(self, cabecalho: str, dados: str) -> NFSeCallRequest:
+        return NFSeCallRequest(
+            nfse_cabec_msg=cabecalho,
+            nfse_dados_msg=dados,
+            wsdl_url=self.wsdl_url,
+            service_url=self.service_url,
+            timeout=self.timeout,
+            verify_ssl=self.verify_ssl,
+        )

--- a/bpo_app/settings.py
+++ b/bpo_app/settings.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+def _parse_bool(value: Optional[str], default: bool) -> bool:
+    if value is None:
+        return default
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "on", "yes"}:
+        return True
+    if lowered in {"0", "false", "off", "no"}:
+        return False
+    return default
+
+
+def _parse_int(value: Optional[str], default: int) -> int:
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _load_env_file() -> None:
+    """Populate environment variables from a local .env file if present."""
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    if not env_path.exists():
+        return
+    try:
+        content = env_path.read_text(encoding="utf-8")
+    except OSError:
+        return
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key and key not in os.environ:
+            os.environ[key] = value.strip()
+
+
+@dataclass(slots=True)
+class Settings:
+    secret_key: str
+    database_url: str
+    admin_email: str
+    admin_password: str
+    admin_password_from_env: bool
+    admin_name: str
+    nfse_wsdl_url: Optional[str]
+    nfse_service_url: Optional[str]
+    nfse_timeout: int
+    nfse_verify_ssl: bool
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        admin_password_env = os.getenv("BPO_ADMIN_PASSWORD")
+        return cls(
+            secret_key=os.getenv("BPO_SECRET_KEY", "troque-essa-chave"),
+            database_url=os.getenv("BPO_DATABASE_URL", "sqlite:///./bpo_finance.db"),
+            admin_email=os.getenv("BPO_ADMIN_EMAIL", "admin@bpo.exemplo.com"),
+            admin_password=admin_password_env if admin_password_env is not None else "admin123",
+            admin_password_from_env=admin_password_env is not None,
+            admin_name=os.getenv("BPO_ADMIN_NAME", "Administrador"),
+            nfse_wsdl_url=os.getenv("BPO_NFSE_WSDL_URL"),
+            nfse_service_url=os.getenv("BPO_NFSE_SERVICE_URL"),
+            nfse_timeout=_parse_int(os.getenv("BPO_NFSE_TIMEOUT"), 30),
+            nfse_verify_ssl=_parse_bool(os.getenv("BPO_NFSE_VERIFY_SSL"), True),
+        )
+
+
+_cached_settings: Optional[Settings] = None
+
+
+def get_settings() -> Settings:
+    global _cached_settings
+    if _cached_settings is None:
+        _load_env_file()
+        _cached_settings = Settings.from_env()
+    return _cached_settings
+
+
+__all__ = ["Settings", "get_settings"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.9'
+
+services:
+  bpo-api:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./:/app
+    environment:
+      - BPO_SECRET_KEY=troque-essa-chave
+      - TZ=America/Sao_Paulo
+    command: uvicorn bpo_app.main:app --host 0.0.0.0 --port 8000 --reload

--- a/docs/manual_canva.md
+++ b/docs/manual_canva.md
@@ -1,0 +1,154 @@
+# Manual Visual do BPO Financeiro
+
+> **Formato sugerido para Canva:** cada seção abaixo corresponde a um slide. Use os blocos de texto como títulos e descrições, adicionando imagens ou ícones conforme desejar.
+
+---
+
+## Slide 1 — Capa inspiradora
+- **Título:** "BPO Financeiro Simples"
+- **Subtítulo:** "Controle financeiro claro para seu escritório e seus clientes"
+- **Destaques:** multiempresas, relatórios visuais, acesso seguro
+
+---
+
+## Slide 2 — Visão geral do sistema
+- **Bloco 1:** "Tudo em um só lugar" — painel administrativo para o contador com visão geral de cada empresa
+- **Bloco 2:** "Clientes com acesso fácil" — cada empresa enxerga apenas seus próprios dados
+- **Bloco 3:** "Relatórios amigáveis" — fluxo de caixa, resultados e listas de contas em linguagem simples
+
+---
+
+## Slide 3 — Checklist pré-instalação
+- Windows 11 ou Linux com acesso a internet
+- Python 3.9 ou superior instalado
+- Porta 8000 liberada na máquina ou servidor
+- Arquivos do repositório baixados (zip ou git clone)
+
+---
+
+## Slide 4 — Instalação Windows 11
+1. Abra o **PowerShell como Administrador**
+2. Acesse a pasta do projeto: `cd CAMINHO\DO\PROJETO`
+3. Entre na pasta `installers`: `cd installers`
+4. Permita scripts temporariamente: `Set-ExecutionPolicy -Scope Process Bypass`
+5. Execute: `./01_windows_installer.ps1`
+6. Aguarde a criação do ambiente virtual e a instalação automática das dependências
+
+> **Dica visual:** destaque o passo final com um callout "Acesse http://localhost:8000".
+
+---
+
+## Slide 5 — Instalação Windows (opções extras)
+- `-Host 127.0.0.1` para restringir o acesso à própria máquina
+- `-Port 9000` se precisar mudar a porta padrão
+- `-SkipRun` para somente instalar e iniciar depois manualmente
+
+> **Como iniciar depois:** `\.venv\Scripts\uvicorn.exe bpo_app.main:app --host 0.0.0.0 --port 8000`
+
+---
+
+## Slide 6 — Instalação VPS Linux (Contábil)
+1. Conecte-se via SSH ao servidor VPS
+2. Acesse a pasta do projeto: `cd /caminho/do/projeto`
+3. Entre na pasta `installers`
+4. Dê permissão de execução: `chmod +x 02_linux_installer.sh`
+5. Rode o script: `./02_linux_installer.sh`
+6. O servidor inicia automaticamente em `http://IP_DA_VPS:8000`
+
+> **Tipografia sugerida:** utilize cores verdes e ícones de terminal para reforçar o fluxo técnico.
+
+---
+
+## Slide 7 — Instalação Linux (opções extras)
+- `./02_linux_installer.sh --skip-run` para instalar sem iniciar
+- `./02_linux_installer.sh --host 127.0.0.1 --port 9000` para personalizar rede
+- Os instaladores criam automaticamente um arquivo `.env` com chave secreta e credenciais iniciais (personalize depois do login).
+
+---
+
+## Slide 8 — Primeiro acesso do escritório
+- Abra `http://localhost:8000`
+- Use o e-mail e a senha exibidos pelo instalador (ou definidos no arquivo `.env`).
+- Assim que entrar, troque a senha do administrador em **Configurações > Segurança**.
+- Cadastre o primeiro cliente em **Empresas > Nova Empresa**
+
+---
+
+## Slide 9 — Convidando clientes
+1. Acesse a empresa recém-criada
+2. Clique em **Equipe da Empresa > Convidar usuário**
+3. Informe nome, e-mail e defina o perfil "Cliente"
+4. Compartilhe o link de acesso com o cliente
+
+> **Sugestão Canva:** usar mockups de e-mail ou chat para ilustrar o convite.
+
+---
+
+## Slide 10 — Cadastro de contas e categorias
+- Use **Finanças > Contas bancárias** para adicionar bancos ou carteiras
+- Crie categorias intuitivas (ex: "Vendas online", "Pagamentos fornecedores")
+- Defina palavras-chave para ajudar na classificação automática
+
+---
+
+## Slide 11 — Importando extratos
+1. Vá em **Finanças > Importar extrato**
+2. Selecione um arquivo CSV, Excel (.xlsx) ou OFX
+3. Confirme a empresa e a conta bancária
+4. Revise as sugestões de categoria antes de salvar
+
+---
+
+## Slide 12 — Lançamentos manuais
+- Clique em **Finanças > Novo lançamento**
+- Informe se é **Entrada** ou **Saída**
+- Preencha valores, data, descrição amigável e categoria
+- Anexe notas ou comprovantes para registrar justificativas
+
+---
+
+## Slide 13 — Relatórios que encantam
+- **Destaques financeiros:** resumo das entradas, saídas e saldo projetado
+- **Fluxo de caixa:** visão por período com gráfico simples
+- **Resultado (DRE simplificada):** linguagem sem jargões contábeis
+- **Contas a pagar/receber:** lista filtrável e exportável
+
+---
+
+## Slide 14 — Exportações
+- Botão **Baixar Excel** disponível em cada relatório
+- Botão **Gerar PDF** para compartilhar com diretoria ou investidores
+- Sugestão: inclua o logotipo do cliente antes de enviar
+
+---
+
+## Slide 15 — Comunicação com o contador
+- Use o quadro **Mensagens rápidas** no painel para enviar solicitações
+- Registre comentários em cada lançamento para histórico
+- Ative notificações por e-mail para avisar quando houver novidades
+
+---
+
+## Slide 16 — Boas práticas de segurança
+- Troque as credenciais padrão imediatamente
+- Utilize senhas fortes e exclusivas
+- Restrinja o acesso por IP na VPS quando possível
+- Faça backup periódico do arquivo `bpo_app.db`
+
+---
+
+## Slide 17 — Próximos passos sugeridos
+- Personalize o visual no Canva com as cores do escritório
+- Crie vídeos curtos de demonstração usando os slides como roteiro
+- Planeje treinamentos rápidos com clientes estratégicos
+
+---
+
+## Slide 18 — Contatos e suporte
+- **Equipe interna:** acesse o painel e use o chat interno para dúvidas
+- **E-mail de suporte:** suporte@seuescritorio.com.br
+- **Atualizações:** acompanhe novas versões no repositório oficial
+
+---
+
+> **Fim do manual.** Personalize os slides à vontade para deixar o material com a identidade visual do escritório.

--- a/docs/pacote_instalacao.md
+++ b/docs/pacote_instalacao.md
@@ -1,0 +1,83 @@
+# Pacote completo para instalação do BPO Financeiro
+
+Este guia reúne todos os arquivos necessários para enviar ao cliente (ou equipe interna) na ordem correta e inclui um manual visual para facilitar a implantação. Combine o conteúdo com o script `tools/create_install_bundle.py` para gerar um arquivo `.zip` pronto para distribuição.
+
+## Como gerar o pacote .zip
+
+```bash
+python tools/create_install_bundle.py
+```
+
+O comando cria `dist/bpo_instalacao.zip` com todos os itens listados abaixo. Para escolher outro destino use `-o`:
+
+```bash
+python tools/create_install_bundle.py -o /caminho/para/pacote.zip
+```
+
+Se desejar enviar apenas os instaladores sem a interface web, acrescente `--skip-frontend`.
+
+## Conteúdo do pacote
+
+1. `README.md` – visão geral do sistema, requisitos e comandos principais.
+2. `requirements.txt` – lista das dependências Python necessárias.
+3. `installers/01_windows_installer.ps1` – script PowerShell para Windows 11.
+4. `installers/02_linux_installer.sh` – script bash para Linux ou VPS.
+5. `installers/README.md` – instruções rápidas sobre os instaladores.
+6. `docs/manual_canva.md` – manual em formato Canva (um slide por seção).
+7. `docs/pacote_instalacao.md` – este guia para acompanhar o envio.
+8. `frontend/` – pastas `index.html`, `styles.css` e `main.js` para quem prefere servir a interface estaticamente.
+9. `MANIFEST.json` – índice automático gerado pelo script com todos os arquivos incluídos.
+
+> **Dica:** compartilhe o `.zip` com clientes ou com a equipe do escritório pelo canal de sua preferência (e-mail, Drive, etc.).
+
+## Sequência sugerida para envio ao cliente final
+
+1. **Anexe o arquivo `.zip`** gerado pelo script.
+2. **Copie a mensagem abaixo**, ajustando apenas os campos em destaque:
+
+   ```
+   Olá, [Nome do cliente]!
+
+   Segue o pacote com tudo o que você precisa para começar a usar o nosso BPO Financeiro.
+   Passos recomendados:
+   1. Descompacte o arquivo em uma pasta simples, como C:\BPO ou /home/usuario/bpo.
+   2. Abra o manual "docs/manual_canva.md" para ver os slides passo a passo.
+   3. Execute o instalador apropriado:
+      - Windows 11: installers/01_windows_installer.ps1
+      - Linux / VPS: installers/02_linux_installer.sh
+   4. Guarde os dados de acesso exibidos ao final da instalação.
+   5. Acesse http://localhost:8000 e personalize a senha imediatamente.
+
+   Qualquer dúvida, nossa equipe está disponível para ajudar.
+   ```
+
+3. **Inclua o manual visual** caso o cliente prefira receber diretamente em Canva: basta importar `docs/manual_canva.md` para o Canva ou outro editor de apresentações.
+4. **Agende uma call de acompanhamento** para revisar o primeiro acesso e garantir que os relatórios estejam claros para o cliente.
+
+## Checklist pós-instalação
+
+- [ ] Trocar a senha padrão do administrador exibida pelo instalador.
+- [ ] Validar importação de um extrato (CSV, Excel ou OFX) para conferir as categorias automáticas.
+- [ ] Gerar um relatório de Fluxo de Caixa e exportar para PDF/Excel.
+- [ ] Revisar o painel administrativo do escritório e confirmar se as empresas aparecem corretamente.
+
+## Perguntas frequentes
+
+### O cliente não consegue executar scripts no Windows
+Peça para abrir o PowerShell como Administrador e rodar:
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass
+```
+
+Depois disso o instalador deve executar normalmente. Caso a restrição continue, envie apenas o comando manual descrito no README (`python -m venv`, `pip install`, etc.).
+
+### O instalador não encontra o Python
+Inclua o link oficial (https://www.python.org/downloads/) na comunicação e oriente a instalar a versão 3.9 ou superior. Após a instalação, peça para abrir um novo terminal e executar o script novamente.
+
+### É possível atualizar o sistema depois de enviado?
+Sim. Envie um novo `.zip` gerado com `create_install_bundle.py`. O cliente pode descompactar por cima da pasta existente ou executar o instalador novamente para atualizar dependências e interface.
+
+---
+
+Com este pacote você tem um kit completo para distribuir o BPO Financeiro de forma profissional, mantendo os passos organizados e fáceis de seguir.

--- a/installers/01_windows_installer.ps1
+++ b/installers/01_windows_installer.ps1
@@ -1,0 +1,100 @@
+[CmdletBinding()]
+param(
+    [string]$Host = "0.0.0.0",
+    [int]$Port = 8000,
+    [switch]$SkipRun
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "==== Instalação do BPO Financeiro (Windows) ====" -ForegroundColor Cyan
+
+function New-RandomString {
+    param(
+        [int]$Length = 32
+    )
+    $chars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%*-_"
+    -join ((1..$Length) | ForEach-Object { $chars[(Get-Random -Maximum $chars.Length)] })
+}
+
+function Get-PythonLauncher {
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if ($pythonCmd) {
+        return @{ Command = $pythonCmd.Source; Args = @() }
+    }
+    $pyLauncher = Get-Command py -ErrorAction SilentlyContinue
+    if ($pyLauncher) {
+        return @{ Command = $pyLauncher.Source; Args = @("-3") }
+    }
+    throw "Python 3 não encontrado. Instale o Python 3.9 ou superior antes de continuar."
+}
+
+$launcher = Get-PythonLauncher
+
+function Invoke-Python {
+    param(
+        [string[]]$Args
+    )
+    & $launcher.Command @($launcher.Args + $Args)
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+if (Test-Path (Join-Path $scriptDir "requirements.txt")) {
+    $repoRoot = $scriptDir
+} else {
+    $repoRoot = Split-Path -Parent $scriptDir
+}
+
+$venvPath = Join-Path $repoRoot ".venv"
+
+if (-not (Test-Path $venvPath)) {
+    Write-Host "Criando ambiente virtual em $venvPath" -ForegroundColor Green
+    Invoke-Python -Args @("-m", "venv", $venvPath)
+} else {
+    Write-Host "Ambiente virtual já existe em $venvPath" -ForegroundColor Yellow
+}
+
+$pythonExe = Join-Path $venvPath "Scripts/python.exe"
+if (-not (Test-Path $pythonExe)) {
+    throw "Não foi possível localizar $pythonExe. Verifique se o Python foi instalado corretamente."
+}
+
+Write-Host "Atualizando pip" -ForegroundColor Green
+& $pythonExe -m pip install --upgrade pip
+
+Write-Host "Instalando dependências" -ForegroundColor Green
+$requirements = Join-Path $repoRoot "requirements.txt"
+& $pythonExe -m pip install -r $requirements
+
+$envFile = Join-Path $repoRoot ".env"
+if (-not (Test-Path $envFile)) {
+    $secretKey = New-RandomString -Length 64
+    $adminPassword = New-RandomString -Length 16
+    $adminEmail = "admin@bpo.local"
+    $envContent = @(
+        "BPO_SECRET_KEY=$secretKey",
+        "BPO_ADMIN_EMAIL=$adminEmail",
+        "BPO_ADMIN_PASSWORD=$adminPassword",
+        "BPO_ADMIN_NAME=Administrador"
+    )
+    Set-Content -Path $envFile -Value $envContent -Encoding UTF8
+    Write-Host "Arquivo .env criado em $envFile" -ForegroundColor Green
+    Write-Host "Credenciais iniciais do administrador:" -ForegroundColor Yellow
+    Write-Host "  E-mail: $adminEmail" -ForegroundColor Yellow
+    Write-Host "  Senha:  $adminPassword" -ForegroundColor Yellow
+    Write-Host "Altere esses valores no arquivo .env após o primeiro acesso." -ForegroundColor Yellow
+} else {
+    Write-Host "Arquivo .env já existe. Mantendo configurações atuais." -ForegroundColor Yellow
+}
+
+$env:PYTHONPATH = $repoRoot
+
+Write-Host "Banco de dados será criado automaticamente ao iniciar o servidor." -ForegroundColor Green
+
+if (-not $SkipRun) {
+    Write-Host "Iniciando servidor em http://$Host:$Port" -ForegroundColor Green
+    & $pythonExe -m uvicorn bpo_app.main:app --host $Host --port $Port
+} else {
+    Write-Host "Instalação concluída. Execute:" -ForegroundColor Green
+    Write-Host "  $venvPath\Scripts\uvicorn.exe bpo_app.main:app --host $Host --port $Port"
+}

--- a/installers/02_linux_installer.sh
+++ b/installers/02_linux_installer.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="0.0.0.0"
+PORT=8000
+RUN_SERVER=1
+PYTHON_BIN=""
+
+usage() {
+    cat <<USAGE
+Uso: ./02_linux_installer.sh [opções]
+
+Opções:
+  --host <ip>     Endereço que o servidor irá escutar (padrão: 0.0.0.0)
+  --port <porta>  Porta do servidor (padrão: 8000)
+  --skip-run      Instala dependências e sai sem iniciar o servidor
+  -h, --help      Mostra esta ajuda
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)
+            HOST="$2"
+            shift 2
+            ;;
+        --port)
+            PORT="$2"
+            shift 2
+            ;;
+        --skip-run)
+            RUN_SERVER=0
+            shift 1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Opção desconhecida: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+else
+    echo "Python 3 não encontrado. Instale o Python 3.9 ou superior e tente novamente." >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$SCRIPT_DIR/requirements.txt" ]]; then
+    REPO_ROOT="$SCRIPT_DIR"
+else
+    REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+VENV_PATH="$REPO_ROOT/.venv"
+
+if [[ ! -d "$VENV_PATH" ]]; then
+    echo "[1/3] Criando ambiente virtual em $VENV_PATH"
+    "$PYTHON_BIN" -m venv "$VENV_PATH"
+else
+    echo "Ambiente virtual já existe em $VENV_PATH"
+fi
+
+# shellcheck disable=SC1090
+source "$VENV_PATH/bin/activate"
+
+echo "[2/3] Atualizando pip"
+pip install --upgrade pip
+
+echo "[3/3] Instalando dependências"
+pip install -r "$REPO_ROOT/requirements.txt"
+
+create_env_file() {
+    local env_file="$REPO_ROOT/.env"
+    if [[ -f "$env_file" ]]; then
+        echo "Arquivo .env já existe. Mantendo configurações atuais."
+        return
+    fi
+    mapfile -t CREDS < <("$VENV_PATH/bin/python" - <<'PY'
+import secrets
+import string
+
+def build(length: int) -> str:
+    alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%*-_"
+    return ''.join(secrets.choice(alphabet) for _ in range(length))
+
+print(build(64))
+print(build(16))
+PY
+)
+    local secret_key="${CREDS[0]}"
+    local admin_password="${CREDS[1]}"
+    local admin_email="admin@bpo.local"
+    cat > "$env_file" <<ENV
+BPO_SECRET_KEY=$secret_key
+BPO_ADMIN_EMAIL=$admin_email
+BPO_ADMIN_PASSWORD=$admin_password
+BPO_ADMIN_NAME=Administrador
+ENV
+    chmod 600 "$env_file"
+    echo "Arquivo .env criado em $env_file"
+    echo "Credenciais iniciais do administrador:" \
+        "\n  E-mail: $admin_email" \
+        "\n  Senha:  $admin_password"
+    echo "Altere os valores do .env após o primeiro acesso."
+}
+
+create_env_file
+
+export PYTHONPATH="$REPO_ROOT"
+
+echo "Banco de dados será criado automaticamente ao iniciar o servidor."
+
+if [[ "$RUN_SERVER" -eq 1 ]]; then
+    echo "Iniciando servidor em http://$HOST:$PORT"
+    exec uvicorn bpo_app.main:app --host "$HOST" --port "$PORT"
+else
+    echo "Instalação concluída. Para iniciar manualmente execute:"
+    echo "  source $VENV_PATH/bin/activate"
+    echo "  uvicorn bpo_app.main:app --host $HOST --port $PORT"
+fi

--- a/installers/README.md
+++ b/installers/README.md
@@ -1,0 +1,9 @@
+# Sequência de arquivos de instalação
+
+1. `01_windows_installer.ps1`
+2. `02_linux_installer.sh`
+
+Cada script é independente e pode ser enviado diretamente ao responsável pela instalação na plataforma correspondente.
+
+- Ambos os scripts geram um arquivo `.env` com a chave secreta e as credenciais iniciais.
+- Para enviar o conjunto completo com manual e frontend, execute `python tools/create_install_bundle.py` na raiz do projeto e encaminhe o arquivo `dist/bpo_instalacao.zip`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,17 @@
 requests>=2.31.0
 Flask>=2.3.0
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0
+SQLAlchemy>=2.0.25
+pydantic>=2.6.0
+email-validator>=2.1.0
+python-multipart>=0.0.6
+passlib[bcrypt]>=1.7.4
+bcrypt>=4.0.1,<5.0.0
+PyJWT>=2.8.0
+pandas>=2.2.0
+openpyxl>=3.1.2
+ofxparse>=0.21
+reportlab>=4.0.7
+httpx>=0.27.0
+zeep>=4.2.1

--- a/tests/test_bpo_app.py
+++ b/tests/test_bpo_app.py
@@ -1,0 +1,468 @@
+import os
+import shutil
+import tempfile
+import unittest
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+os.environ.setdefault("BPO_SECRET_KEY", "test-secret-key")
+os.environ.setdefault("BPO_ADMIN_EMAIL", "admin@test.example")
+os.environ.setdefault("BPO_ADMIN_PASSWORD", "SenhaForte!123")
+os.environ.setdefault("BPO_ADMIN_NAME", "Administrador Teste")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from bpo_app import database, main  # noqa: E402
+from tools.run_diagnostics import collect_diagnostics  # noqa: E402
+
+
+class BPOAppFlowTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.mkdtemp(prefix="bpo_test_")
+        self.db_path = Path(self.temp_dir) / "test.db"
+        database.init_engine(f"sqlite:///{self.db_path}")
+        self.client_ctx = TestClient(main.app)
+        self.client = self.client_ctx.__enter__()
+
+    def tearDown(self) -> None:
+        self.client_ctx.__exit__(None, None, None)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def auth_headers(self) -> dict[str, str]:
+        response = self.client.post(
+            "/auth/login",
+            json={
+                "email": os.environ["BPO_ADMIN_EMAIL"],
+                "password": os.environ["BPO_ADMIN_PASSWORD"],
+            },
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        token = response.json()["access_token"]
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_login_accepts_uppercase_email(self) -> None:
+        response = self.client.post(
+            "/auth/login",
+            json={
+                "email": os.environ["BPO_ADMIN_EMAIL"].upper(),
+                "password": os.environ["BPO_ADMIN_PASSWORD"],
+            },
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+    def test_login_with_invalid_email_format_returns_unauthorized(self) -> None:
+        response = self.client.post(
+            "/auth/login",
+            json={"email": "usuario", "password": os.environ["BPO_ADMIN_PASSWORD"]},
+        )
+        self.assertEqual(response.status_code, 401, response.text)
+
+    def test_admin_password_sync_from_env(self) -> None:
+        email = os.environ["BPO_ADMIN_EMAIL"]
+        original_password = os.environ["BPO_ADMIN_PASSWORD"]
+        response = self.client.post(
+            "/auth/login",
+            json={"email": email, "password": original_password},
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        new_password = "NovaSenha!456"
+        main.settings.admin_password = new_password
+        main.settings.admin_password_from_env = True
+        try:
+            main.on_startup()
+            updated_login = self.client.post(
+                "/auth/login",
+                json={"email": email, "password": new_password},
+            )
+            self.assertEqual(updated_login.status_code, 200, updated_login.text)
+
+            old_password_login = self.client.post(
+                "/auth/login",
+                json={"email": email, "password": original_password},
+            )
+            self.assertEqual(old_password_login.status_code, 401, old_password_login.text)
+        finally:
+            main.settings.admin_password = original_password
+            main.settings.admin_password_from_env = True
+            main.on_startup()
+
+    def test_startup_creates_admin_for_new_email(self) -> None:
+        original_email = main.settings.admin_email
+        original_password = main.settings.admin_password
+        original_password_from_env = main.settings.admin_password_from_env
+
+        new_email = "novo-admin@test.example"
+        new_password = "SenhaNova!789"
+
+        main.settings.admin_email = new_email
+        main.settings.admin_password = new_password
+        main.settings.admin_password_from_env = True
+
+        try:
+            main.on_startup()
+
+            response = self.client.post(
+                "/auth/login",
+                json={"email": new_email, "password": new_password},
+            )
+            self.assertEqual(response.status_code, 200, response.text)
+        finally:
+            main.settings.admin_email = original_email
+            main.settings.admin_password = original_password
+            main.settings.admin_password_from_env = original_password_from_env
+            main.on_startup()
+
+    def test_collect_diagnostics_reports_expected_information(self) -> None:
+        result = collect_diagnostics()
+        self.assertEqual(result.missing_modules, [])
+        self.assertGreaterEqual(result.database["admins"], 1)
+        self.assertIn("frontend_index", result.assets)
+
+    def test_end_to_end_flow(self) -> None:
+        headers = self.auth_headers()
+
+        company_payload = {
+            "name": "Empresa Teste Ltda",
+            "trade_name": "Empresa Teste",
+            "document": "12345678000199",
+            "notes": "Cliente piloto",
+        }
+        company_resp = self.client.post("/companies", json=company_payload, headers=headers)
+        self.assertEqual(company_resp.status_code, 200, company_resp.text)
+        company_id = company_resp.json()["id"]
+
+        account_payload = {
+            "company_id": company_id,
+            "name": "Conta Principal",
+            "bank_name": "Banco Teste",
+            "account_number": "1234-5",
+            "initial_balance": 1000.0,
+        }
+        account_resp = self.client.post("/bank-accounts", json=account_payload, headers=headers)
+        self.assertEqual(account_resp.status_code, 200, account_resp.text)
+        account_id = account_resp.json()["id"]
+
+        transaction_payload = {
+            "company_id": company_id,
+            "bank_account_id": account_id,
+            "date": date.today().isoformat(),
+            "description": "Recebimento de venda",
+            "amount": 2500.0,
+            "transaction_type": "inflow",
+        }
+        txn_resp = self.client.post("/transactions", json=transaction_payload, headers=headers)
+        self.assertEqual(txn_resp.status_code, 200, txn_resp.text)
+        txn_data = txn_resp.json()
+        self.assertTrue(txn_data["auto_classified"])
+
+        csv_content = "data,descricao,valor,tipo\n" "2024-01-05,Pagamento fornecedor,1500,saida\n"
+        files = {"file": ("extrato.csv", csv_content, "text/csv")}
+        import_resp = self.client.post(
+            f"/transactions/import?company_id={company_id}",
+            headers=headers,
+            files=files,
+        )
+        self.assertEqual(import_resp.status_code, 200, import_resp.text)
+        summary = import_resp.json()
+        self.assertEqual(summary["imported"], summary["total_records"])
+
+        list_resp = self.client.get(f"/transactions?company_id={company_id}", headers=headers)
+        self.assertEqual(list_resp.status_code, 200, list_resp.text)
+        transactions = list_resp.json()
+        self.assertGreaterEqual(len(transactions), 2)
+
+        start_date = (date.today().replace(day=1) - timedelta(days=30)).isoformat()
+        end_date = date.today().isoformat()
+        report_resp = self.client.get(
+            f"/reports/financial-health?company_id={company_id}&start_date={start_date}&end_date={end_date}",
+            headers=headers,
+        )
+        self.assertEqual(report_resp.status_code, 200, report_resp.text)
+        report_data = report_resp.json()
+        self.assertIn("cash_flow", report_data)
+        self.assertIn("dre", report_data)
+
+        export_xlsx = self.client.get(
+            f"/reports/export?company_id={company_id}&start_date={start_date}&end_date={end_date}&export_format=xlsx",
+            headers=headers,
+        )
+        self.assertEqual(export_xlsx.status_code, 200, export_xlsx.text)
+        self.assertIn(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            export_xlsx.headers.get("content-type", ""),
+        )
+
+        export_pdf = self.client.get(
+            f"/reports/export?company_id={company_id}&start_date={start_date}&end_date={end_date}&export_format=pdf",
+            headers=headers,
+        )
+        self.assertEqual(export_pdf.status_code, 200, export_pdf.text)
+
+    def test_financial_goals_and_tasks_flow(self) -> None:
+        headers = self.auth_headers()
+
+        company_payload = {
+            "name": "Cliente Metas Ltda",
+            "trade_name": "Cliente Metas",
+            "document": "99887766000155",
+            "notes": "Testa metas e tarefas",
+        }
+        company_resp = self.client.post("/companies", json=company_payload, headers=headers)
+        self.assertEqual(company_resp.status_code, 200, company_resp.text)
+        company_id = company_resp.json()["id"]
+
+        account_payload = {
+            "company_id": company_id,
+            "name": "Conta Operacional",
+            "bank_name": "Banco Demo",
+            "account_number": "0001-9",
+            "initial_balance": 0,
+        }
+        account_resp = self.client.post("/bank-accounts", json=account_payload, headers=headers)
+        self.assertEqual(account_resp.status_code, 200, account_resp.text)
+        account_id = account_resp.json()["id"]
+
+        period_start = date.today().replace(day=1)
+        period_end = period_start + timedelta(days=30)
+
+        goal_payload = {
+            "company_id": company_id,
+            "name": "Meta de Receita",
+            "description": "Alcançar R$ 5.000 em vendas",
+            "direction": "inflow",
+            "target_amount": 5000.0,
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+        }
+        goal_resp = self.client.post("/financial-goals", json=goal_payload, headers=headers)
+        self.assertEqual(goal_resp.status_code, 200, goal_resp.text)
+        goal_id = goal_resp.json()["id"]
+
+        transaction_payload = {
+            "company_id": company_id,
+            "bank_account_id": account_id,
+            "date": (period_start + timedelta(days=3)).isoformat(),
+            "description": "Venda de serviço",
+            "amount": 3200.0,
+            "transaction_type": "inflow",
+        }
+        txn_resp = self.client.post("/transactions", json=transaction_payload, headers=headers)
+        self.assertEqual(txn_resp.status_code, 200, txn_resp.text)
+
+        goals_list = self.client.get(f"/financial-goals?company_id={company_id}", headers=headers)
+        self.assertEqual(goals_list.status_code, 200, goals_list.text)
+        goals_data = goals_list.json()
+        self.assertEqual(len(goals_data), 1)
+        self.assertEqual(goals_data[0]["goal"]["name"], "Meta de Receita")
+        self.assertGreater(goals_data[0]["actual_amount"], 0)
+
+        goals_summary = self.client.get(
+            f"/financial-goals/summary?company_id={company_id}", headers=headers
+        )
+        self.assertEqual(goals_summary.status_code, 200, goals_summary.text)
+        goals_summary_data = goals_summary.json()
+        self.assertEqual(goals_summary_data["total"], 1)
+        self.assertEqual(goals_summary_data["archived"], 0)
+        self.assertEqual(goals_summary_data["in_progress"], 1)
+        self.assertEqual(goals_summary_data["achieved"], 0)
+        self.assertEqual(goals_summary_data["next_deadline"], goal_payload["period_end"])
+        self.assertEqual(len(goals_summary_data["upcoming"]), 1)
+        self.assertEqual(goals_summary_data["upcoming"][0]["goal"]["id"], goal_id)
+
+        update_goal = self.client.put(
+            f"/financial-goals/{goal_id}", json={"archived": True}, headers=headers
+        )
+        self.assertEqual(update_goal.status_code, 200, update_goal.text)
+        self.assertTrue(update_goal.json()["archived"])
+
+        archived_summary = self.client.get(
+            f"/financial-goals/summary?company_id={company_id}", headers=headers
+        )
+        self.assertEqual(archived_summary.status_code, 200, archived_summary.text)
+        archived_summary_data = archived_summary.json()
+        self.assertEqual(archived_summary_data["archived"], 1)
+        self.assertEqual(len(archived_summary_data["upcoming"]), 0)
+
+        task_payload = {
+            "company_id": company_id,
+            "title": "Enviar notas fiscais",
+            "description": "Separar documentos da semana",
+            "status": "open",
+            "due_date": (period_start + timedelta(days=5)).isoformat(),
+        }
+        task_resp = self.client.post("/tasks", json=task_payload, headers=headers)
+        self.assertEqual(task_resp.status_code, 200, task_resp.text)
+        task_id = task_resp.json()["id"]
+
+        task_summary_initial = self.client.get(
+            f"/tasks/summary?company_id={company_id}", headers=headers
+        )
+        self.assertEqual(task_summary_initial.status_code, 200, task_summary_initial.text)
+        task_summary_initial_data = task_summary_initial.json()
+        self.assertEqual(task_summary_initial_data["open"], 1)
+        self.assertEqual(task_summary_initial_data["in_progress"], 0)
+        self.assertEqual(task_summary_initial_data["done"], 0)
+        self.assertEqual(len(task_summary_initial_data["spotlight"]), 1)
+        self.assertEqual(task_summary_initial_data["spotlight"][0]["id"], task_id)
+
+        progress_task = self.client.put(
+            f"/tasks/{task_id}", json={"status": "in_progress"}, headers=headers
+        )
+        self.assertEqual(progress_task.status_code, 200, progress_task.text)
+
+        task_summary_in_progress = self.client.get(
+            f"/tasks/summary?company_id={company_id}", headers=headers
+        )
+        self.assertEqual(task_summary_in_progress.status_code, 200, task_summary_in_progress.text)
+        task_summary_in_progress_data = task_summary_in_progress.json()
+        self.assertEqual(task_summary_in_progress_data["open"], 0)
+        self.assertEqual(task_summary_in_progress_data["in_progress"], 1)
+
+        complete_task = self.client.put(
+            f"/tasks/{task_id}", json={"status": "done"}, headers=headers
+        )
+        self.assertEqual(complete_task.status_code, 200, complete_task.text)
+        self.assertIsNotNone(complete_task.json()["completed_at"])
+
+        task_summary_done = self.client.get(
+            f"/tasks/summary?company_id={company_id}", headers=headers
+        )
+        self.assertEqual(task_summary_done.status_code, 200, task_summary_done.text)
+        task_summary_done_data = task_summary_done.json()
+        self.assertEqual(task_summary_done_data["done"], 1)
+        self.assertEqual(task_summary_done_data["open"], 0)
+        self.assertEqual(task_summary_done_data["in_progress"], 0)
+        self.assertEqual(len(task_summary_done_data["spotlight"]), 0)
+
+        tasks_list = self.client.get(f"/tasks?company_id={company_id}", headers=headers)
+        self.assertEqual(tasks_list.status_code, 200, tasks_list.text)
+        tasks_data = tasks_list.json()
+        self.assertEqual(len(tasks_data), 1)
+        self.assertEqual(tasks_data[0]["status"], "done")
+
+        delete_task = self.client.delete(f"/tasks/{task_id}", headers=headers)
+        self.assertEqual(delete_task.status_code, 200, delete_task.text)
+
+        delete_goal = self.client.delete(f"/financial-goals/{goal_id}", headers=headers)
+        self.assertEqual(delete_goal.status_code, 200, delete_goal.text)
+        dashboard_resp = self.client.get("/dashboard/overview", headers=headers)
+        self.assertEqual(dashboard_resp.status_code, 200, dashboard_resp.text)
+        highlights = dashboard_resp.json()
+        self.assertTrue(any(item["title"] for item in highlights))
+
+    def test_nfse_route_uses_stubbed_client(self) -> None:
+        headers = self.auth_headers()
+
+        calls: list[tuple[str, str, str]] = []
+
+        class StubClient:
+            async def call_operation(self, operation: str, cabec: str, dados: str) -> str:
+                calls.append((operation, cabec, dados))
+                return "<xml-retorno />"
+
+        original_resolver = main.resolve_nfse_client
+
+        def fake_resolver(config, use_cache: bool = True):
+            self.assertEqual(config.wsdl_url, "http://nfse.example/wsdl")
+            self.assertEqual(config.service_url, "http://nfse.example/nfse.asmx")
+            return StubClient()
+
+        main.resolve_nfse_client = fake_resolver  # type: ignore[assignment]
+        try:
+            response = self.client.post(
+                "/integrations/nfse/ConsultarNfsePorRps",
+                headers=headers,
+                json={
+                    "nfse_cabec_msg": "<cabecalho />",
+                    "nfse_dados_msg": "<dados />",
+                    "wsdl_url": "http://nfse.example/wsdl",
+                    "service_url": "http://nfse.example/nfse.asmx",
+                },
+            )
+        finally:
+            main.resolve_nfse_client = original_resolver  # type: ignore[assignment]
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()["output_xml"], "<xml-retorno />")
+        self.assertEqual(calls[0][0], "ConsultarNfsePorRps")
+
+    def test_goiania_nfse_emission_endpoint_builds_payload(self) -> None:
+        headers = self.auth_headers()
+
+        captured: dict[str, str] = {}
+
+        class StubClient:
+            async def call_operation(self, operation: str, cabec: str, dados: str) -> str:
+                captured["operation"] = operation
+                captured["cabecalho"] = cabec
+                captured["dados"] = dados
+                return "<nfse-retorno />"
+
+        original_resolver = main.resolve_nfse_client
+
+        def fake_resolver(config, use_cache: bool = True):
+            self.assertEqual(config.wsdl_url, "http://nfse.example/wsdl")
+            self.assertEqual(config.service_url, "http://nfse.example/nfse.asmx")
+            return StubClient()
+
+        main.resolve_nfse_client = fake_resolver  # type: ignore[assignment]
+        try:
+            response = self.client.post(
+                "/integrations/nfse/goiania/emissao",
+                headers=headers,
+                json={
+                    "numero_lote": "20240001",
+                    "numero_rps": "15",
+                    "serie_rps": "GO",
+                    "tipo_rps": 1,
+                    "data_emissao": datetime(2024, 1, 10, 10, 30, 0).isoformat(),
+                    "natureza_operacao": 1,
+                    "regime_especial_tributacao": 6,
+                    "optante_simples": 1,
+                    "incentivador_cultural": 2,
+                    "status_rps": 1,
+                    "prestador": {
+                        "cnpj": "12.345.678/0001-99",
+                        "inscricao_municipal": "123456",
+                    },
+                    "servico": {
+                        "item_lista_servico": "0701",
+                        "codigo_tributacao_municipio": "070199",
+                        "discriminacao": "Serviço de gestão financeira mensal",
+                        "valores": {
+                            "valor_servicos": "1500.00",
+                            "iss_retido": 2,
+                        },
+                    },
+                    "tomador": {
+                        "razao_social": "Cliente NFSe Teste LTDA",
+                        "cpf_cnpj": "00.987.654/3210-00",
+                        "email": "cliente@teste.com",
+                        "telefone": "62999990000",
+                        "endereco": {
+                            "logradouro": "Rua Central",
+                            "numero": "100",
+                            "bairro": "Centro",
+                            "codigo_municipio": "5208707",
+                            "uf": "GO",
+                            "cep": "74000000",
+                        },
+                    },
+                    "wsdl_url": "http://nfse.example/wsdl",
+                    "service_url": "http://nfse.example/nfse.asmx",
+                },
+            )
+        finally:
+            main.resolve_nfse_client = original_resolver  # type: ignore[assignment]
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()["output_xml"], "<nfse-retorno />")
+        self.assertEqual(captured.get("operation"), "GerarNfse")
+        self.assertIn("GerarNfseEnvio", captured.get("dados", ""))
+        self.assertIn("<Numero>15</Numero>", captured.get("dados", ""))
+        self.assertIn("<RazaoSocial>Cliente NFSe Teste LTDA</RazaoSocial>", captured.get("dados", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nfse_client.py
+++ b/tests/test_nfse_client.py
@@ -1,0 +1,28 @@
+import unittest
+
+from bpo_app.nfse_client import (
+    NFSeClientConfig,
+    NFSeConfigurationError,
+    _normalize_address,
+)
+
+
+class NFSeClientUnitTest(unittest.TestCase):
+    def test_normalizes_relative_service_address(self) -> None:
+        result = _normalize_address("https://nfse.exemplo.gov.br/nfse?wsdl", "nfse.asmx")
+        self.assertEqual(result, "https://nfse.exemplo.gov.br/nfse.asmx")
+
+    def test_config_normalizes_relative_service_url(self) -> None:
+        config = NFSeClientConfig(
+            wsdl_url="https://nfse.exemplo.gov.br/nfse?wsdl",
+            service_url="nfse.asmx",
+        )
+        self.assertEqual(config.service_url, "https://nfse.exemplo.gov.br/nfse.asmx")
+
+    def test_raises_for_missing_address(self) -> None:
+        with self.assertRaises(NFSeConfigurationError):
+            _normalize_address("https://nfse.exemplo.gov.br/nfse?wsdl", "   ")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nfse_goiania.py
+++ b/tests/test_nfse_goiania.py
@@ -1,0 +1,62 @@
+import unittest
+from datetime import datetime
+from decimal import Decimal
+
+from bpo_app.nfse_goiania import (
+    GoianiaNfseEmission,
+    GoianiaPrestador,
+    GoianiaServico,
+    GoianiaServicoValores,
+    GoianiaTomador,
+    GoianiaTomadorEndereco,
+    build_goiania_payload,
+)
+
+
+class GoianiaNFSeBuilderTest(unittest.TestCase):
+    def test_payload_contains_core_elements(self) -> None:
+        emission = GoianiaNfseEmission(
+            numero_lote="20240001",
+            numero_rps="15",
+            serie_rps="GO",
+            tipo_rps=1,
+            data_emissao=datetime(2024, 1, 10, 10, 30, 0),
+            natureza_operacao=1,
+            regime_especial_tributacao=6,
+            optante_simples=1,
+            incentivador_cultural=2,
+            status_rps=1,
+            prestador=GoianiaPrestador(cnpj="12.345.678/0001-99", inscricao_municipal="123456"),
+            servico=GoianiaServico(
+                valores=GoianiaServicoValores(valor_servicos=Decimal("1500.00")),
+                item_lista_servico="0701",
+                codigo_tributacao_municipio="070199",
+                discriminacao="Serviço de gestão financeira mensal",
+            ),
+            tomador=GoianiaTomador(
+                razao_social="Cliente NFSe Teste LTDA",
+                cpf_cnpj="00.987.654/3210-00",
+                inscricao_municipal=None,
+                email="cliente@teste.com",
+                telefone="62999990000",
+                endereco=GoianiaTomadorEndereco(
+                    logradouro="Rua Central",
+                    numero="100",
+                    bairro="Centro",
+                    cep="74000000",
+                ),
+            ),
+        )
+
+        cabecalho, dados = build_goiania_payload(emission)
+
+        self.assertIn("<VersaoDados>2.03</VersaoDados>", cabecalho)
+        self.assertIn("GerarNfseEnvio", dados)
+        self.assertIn("<Numero>15</Numero>", dados)
+        self.assertIn("<Cnpj>12345678000199</Cnpj>", dados)
+        self.assertIn("<CodigoMunicipio>5208707</CodigoMunicipio>", dados)
+        self.assertIn("<RazaoSocial>Cliente NFSe Teste LTDA</RazaoSocial>", dados)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/create_install_bundle.py
+++ b/tools/create_install_bundle.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Gera um pacote ZIP com tudo o que o cliente precisa para instalar o BPO."""
+from __future__ import annotations
+
+import argparse
+import json
+import zipfile
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = ROOT / "dist" / "bpo_instalacao.zip"
+
+FILES_TO_INCLUDE: Tuple[Tuple[str, str], ...] = (
+    ("README.md", "README.md"),
+    ("requirements.txt", "requirements.txt"),
+    ("installers/01_windows_installer.ps1", "installers/01_windows_installer.ps1"),
+    ("installers/02_linux_installer.sh", "installers/02_linux_installer.sh"),
+    ("installers/README.md", "installers/README.md"),
+    ("docs/manual_canva.md", "docs/manual_canva.md"),
+    ("docs/pacote_instalacao.md", "docs/pacote_instalacao.md"),
+)
+
+DIRECTORIES_TO_INCLUDE: Tuple[Tuple[str, str], ...] = (
+    ("bpo_app/frontend", "frontend"),
+)
+
+
+def _resolve_item(source: str, target: str) -> Dict[str, str]:
+    src_path = ROOT / source
+    if not src_path.exists():
+        raise FileNotFoundError(f"Arquivo obrigatório não encontrado: {source}")
+    return {"source": str(src_path), "target": target}
+
+
+def _iter_directory_items(source: str, target_root: str) -> Iterable[Dict[str, str]]:
+    base = ROOT / source
+    if not base.exists():
+        raise FileNotFoundError(f"Diretório obrigatório não encontrado: {source}")
+    for path in base.rglob("*"):
+        if path.is_dir():
+            continue
+        relative = path.relative_to(base).as_posix()
+        yield {"source": str(path), "target": f"{target_root}/{relative}"}
+
+
+def build_bundle(output: Path, include_frontend: bool = True) -> Dict[str, object]:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    manifest_items = []
+
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+        for source, target in FILES_TO_INCLUDE:
+            info = _resolve_item(source, target)
+            bundle.write(info["source"], info["target"])
+            manifest_items.append({"type": "file", **info})
+
+        if include_frontend:
+            for source, target_root in DIRECTORIES_TO_INCLUDE:
+                for info in _iter_directory_items(source, target_root):
+                    bundle.write(info["source"], info["target"])
+                    manifest_items.append({"type": "asset", **info})
+
+        manifest = {
+            "count": len(manifest_items),
+            "items": manifest_items,
+        }
+        bundle.writestr("MANIFEST.json", json.dumps(manifest, indent=2, ensure_ascii=False))
+
+    return {"archive": str(output), "count": len(manifest_items)}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Gera um pacote ZIP com scripts de instalação, manual e frontend "
+            "para compartilhamento rápido com clientes."
+        )
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Caminho do arquivo ZIP de saída (padrão: {DEFAULT_OUTPUT})",
+    )
+    parser.add_argument(
+        "--skip-frontend",
+        action="store_true",
+        help="Não incluir os arquivos da interface web no pacote.",
+    )
+    args = parser.parse_args()
+
+    result = build_bundle(args.output, include_frontend=not args.skip_frontend)
+    print(
+        "Pacote gerado em {path} contendo {count} itens.".format(
+            path=result["archive"],
+            count=result["count"],
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_diagnostics.py
+++ b/tools/run_diagnostics.py
@@ -1,0 +1,152 @@
+"""Ferramentas de verificação rápida do ambiente do BPO Financeiro."""
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+from bpo_app import database, main as app_main
+from bpo_app.models import Company, User, UserRole
+from bpo_app.settings import get_settings
+
+
+MODULE_CHECKS: Dict[str, str] = {
+    "fastapi": "API principal e autenticação",
+    "uvicorn": "Servidor ASGI para rodar o backend",
+    "sqlalchemy": "Camada de acesso ao banco de dados",
+    "pydantic": "Validação e serialização de dados",
+    "pandas": "Importação e relatórios financeiros",
+    "openpyxl": "Importação de planilhas Excel",
+    "ofxparse": "Importação de extratos OFX",
+    "reportlab": "Exportação de relatórios em PDF",
+    "zeep": "Integração NFSe (SOAP)",
+}
+
+
+@dataclass
+class ModuleStatus:
+    name: str
+    purpose: str
+
+
+@dataclass
+class DiagnosticsResult:
+    missing_modules: List[ModuleStatus]
+    settings_warnings: List[str]
+    database: Dict[str, int]
+    assets: Dict[str, bool]
+
+
+def _check_modules() -> List[ModuleStatus]:
+    missing: List[ModuleStatus] = []
+    for module_name, purpose in MODULE_CHECKS.items():
+        try:
+            importlib.import_module(module_name)
+        except ImportError:
+            missing.append(ModuleStatus(name=module_name, purpose=purpose))
+    return missing
+
+
+def _check_settings() -> List[str]:
+    warnings: List[str] = []
+    settings = get_settings()
+    if settings.secret_key == "troque-essa-chave":
+        warnings.append(
+            "Defina BPO_SECRET_KEY com um valor seguro para proteger os tokens de acesso."
+        )
+    if not settings.admin_password_from_env and settings.admin_password == "admin123":
+        warnings.append(
+            "Defina BPO_ADMIN_PASSWORD com uma senha forte ou altere a senha do administrador."
+        )
+    if settings.database_url.startswith("sqlite"):
+        warnings.append(
+            "O banco de dados está em SQLite. Planeje a migração para PostgreSQL antes de produção."
+        )
+    return warnings
+
+
+def _check_database() -> Dict[str, int]:
+    app_main.on_startup()
+
+    session_factory = database.get_sessionmaker()
+    with session_factory() as session:
+        user_count = session.query(User).count()
+        admin_count = session.query(User).filter(User.role == UserRole.ADMIN).count()
+        company_count = session.query(Company).count()
+    return {
+        "users": user_count,
+        "admins": admin_count,
+        "companies": company_count,
+    }
+
+
+def _check_assets() -> Dict[str, bool]:
+    base_path = Path(__file__).resolve().parent.parent
+    frontend_dir = base_path / "bpo_app" / "frontend"
+    return {
+        "frontend_index": (frontend_dir / "index.html").is_file(),
+        "frontend_scripts": (frontend_dir / "main.js").is_file(),
+        "frontend_styles": (frontend_dir / "styles.css").is_file(),
+        "manual_canva": (base_path / "docs" / "manual_canva.md").is_file(),
+        "installers_folder": (base_path / "installers").is_dir(),
+    }
+
+
+def collect_diagnostics() -> DiagnosticsResult:
+    return DiagnosticsResult(
+        missing_modules=_check_modules(),
+        settings_warnings=_check_settings(),
+        database=_check_database(),
+        assets=_check_assets(),
+    )
+
+
+def run_cli() -> None:
+    parser = argparse.ArgumentParser(
+        description="Executa verificações rápidas de ambiente e instalação do BPO Financeiro."
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Retorna a saída em formato JSON compacto"
+    )
+    args = parser.parse_args()
+
+    result = collect_diagnostics()
+    if args.json:
+        print(json.dumps(asdict(result), ensure_ascii=False, indent=2))
+        return
+
+    if result.missing_modules:
+        print("⚠️  Módulos Python ausentes:")
+        for item in result.missing_modules:
+            print(f"  - {item.name}: {item.purpose}")
+    else:
+        print("✅ Todas as dependências Python principais estão instaladas.")
+
+    if result.settings_warnings:
+        print("\n⚠️  Ajustes recomendados nas configurações:")
+        for warning in result.settings_warnings:
+            print(f"  - {warning}")
+    else:
+        print("\n✅ Variáveis de ambiente essenciais configuradas.")
+
+    db_info = result.database
+    print(
+        f"\n📊 Banco de dados: {db_info['users']} usuário(s), {db_info['admins']} admin(s), {db_info['companies']} empresa(s)."
+    )
+
+    print("\n🗂️  Itens de instalação e frontend:")
+    for asset, exists in result.assets.items():
+        status = "OK" if exists else "Faltando"
+        print(f"  - {asset.replace('_', ' ').title()}: {status}")
+
+
+if __name__ == "__main__":
+    run_cli()


### PR DESCRIPTION
## Summary
- add backend schemas and endpoints that summarize financial goals and checklist tasks with upcoming deadlines and spotlight items
- surface the new metrics in the dashboard with refreshed goal and task panels plus responsive styling updates
- expand the integration tests and README notes to cover the additional insights available to offices and clients

## Testing
- python -m unittest discover -s tests -v
- python -m compileall bpo_app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68f083240f708329b826db6a0b03ad1f)