### PR TITLE
Add Goiânia NFS-e emission support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Sistema completo para coleta automatizada de documentos fiscais eletrônicos (NF
 
 ## Configuração Inicial
 1. Copie `.env.example` para `.env` e ajuste as variáveis conforme necessário.
-2. Instale as dependências utilizando um ambiente virtual:
+2. Instale as dependências utilizando um ambiente virtual (ou simplesmente execute `install.bat` no Windows / `install.sh` no Linux para automatizar todo o processo):
    ```bash
    python -m venv .venv
    source .venv/bin/activate          # Linux/macOS
@@ -34,7 +34,7 @@ Sistema completo para coleta automatizada de documentos fiscais eletrônicos (NF
    python -m pip install -r requirements.txt
    ```
    > 💡 **Windows 11:** Com Python 3.13 certifique-se de atualizar o `pip` (`python -m pip install --upgrade pip`) para baixar o wheel oficial do `lxml 5.3.x`. Caso utilize versões mais antigas do `lxml`, será necessário instalar o [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
-3. Execute o painel Streamlit:
+3. Execute o painel Streamlit (**não** execute `py web/app.py`; use o comando do Streamlit ou o `start.bat`/`start.sh` para que as dependências sejam carregadas automaticamente):
    ```bash
    python -m streamlit run web/app.py --server.port 8501
    ```
@@ -47,8 +47,12 @@ Sistema completo para coleta automatizada de documentos fiscais eletrônicos (NF
 ### Scripts rápidos para Windows
 - `install.bat`: instalação padrão (cria/atualiza `.venv` e dependências).
 - `force_install.bat`: reinstalação completa, removendo e recriando o ambiente virtual.
-- `start.bat`: inicialização do painel Streamlit utilizando o ambiente configurado.
+- `start.bat`: inicialização do painel Streamlit utilizando o ambiente configurado; se o ambiente ou o Streamlit não estiverem instalados, o script executa a instalação automaticamente.
 - `verify.bat`: verificação rápida do ambiente (versão do Python, `pip check` e compilação das pastas `app/` e `web/`).
+
+> ℹ️ **Erro “ModuleNotFoundError: No module named 'streamlit'”**
+> - Verifique se você instalou as dependências (`install.bat` no Windows ou `install.sh` no Linux) antes de iniciar.
+> - Utilize `start.bat` (Windows) ou `python -m streamlit run web/app.py` (Linux/macOS) em vez de `py app.py`, pois o aplicativo precisa ser executado pelo CLI do Streamlit.
 
 
 ## Cadastro de Empresas

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Sistema completo para coleta automatizada de documentos fiscais eletrônicos (NF
    - Parâmetros opcionais `--usuario-portal` e `--senha-portal` permitem informar credenciais diferentes do CNPJ.
 4. O script cria/usa `.venv`, instala dependências e grava os arquivos no diretório `data/nfse/` respeitando empresa/ano/mês.
 5. Em caso de mudança de layout ou captcha complexo, o módulo registra logs em `logs/coletor.log` para ajuste rápido.
+6. A CLI inicializa o banco SQLite automaticamente (criando a tabela de empresas caso o painel ainda não tenha sido aberto) e valida
+   a presença do certificado `.pfx` antes de enviar os dados.
 
 ## Execução com Systemd
 O script `install.sh` configura o ambiente em servidores Linux (Ubuntu) criando um serviço systemd para o painel Streamlit. Revise o arquivo antes de executar para ajustar caminhos ou usuário do serviço.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Sistema completo para coleta automatizada de documentos fiscais eletrônicos (NF
 6. A CLI inicializa o banco SQLite automaticamente (criando a tabela de empresas caso o painel ainda não tenha sido aberto) e valida
    a presença do certificado `.pfx` antes de enviar os dados.
 
+### Avaliação da API `sped-nfse-amtec`
+- O pacote PHP `nfephp-org/sped-nfse-amtec` (AMTEC/ABRASF 2.0) expõe o webservice SOAP oficial de Goiânia (`GerarNfse` e `ConsultarNfseRps`).
+- Por ser PHP/Composer e possuir apenas métodos síncronos, a integração direta exige ou um microserviço PHP ou a reimplementação dos envelopes SOAP em Python.
+- Restrições importantes: uso de certificado PFX do CNPJ cadastrado, endpoint único para TESTE/PRODUÇÃO e diversas tags ABRASF que não podem ser enviadas (ex.: `ValorIss`, `ItemListaServico`, `Competencia`).
+- Consulte `docs/nfse_amtec_analysis.md` para o detalhamento completo e passos recomendados caso optemos por essa integração.
+
 ## Execução com Systemd
 O script `install.sh` configura o ambiente em servidores Linux (Ubuntu) criando um serviço systemd para o painel Streamlit. Revise o arquivo antes de executar para ajustar caminhos ou usuário do serviço.
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Sistema completo para coleta automatizada de documentos fiscais eletrônicos (NF
 - Requisitos adicionais:
   - `pytesseract` + mecanismo Tesseract instalado no sistema para resolver o captcha automaticamente (Linux: `sudo apt install tesseract-ocr`; Windows: [instalador oficial](https://github.com/UB-Mannheim/tesseract/wiki)).
   - Certificado `.pfx` da empresa na pasta `certs/` e senha correspondente.
+  - O payload da nota é validado antes do envio (tomador/serviço obrigatórios) e o download do XML repete em caso de falhas de rede.
 
 ### Passo a passo (CLI)
 1. Cadastre a empresa no painel Streamlit, informando CNPJ e senha do certificado.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ Sistema completo para coleta automatizada de documentos fiscais eletrônicos (NF
 3. Clique em **🔄 Coletar Agora** para executar as rotinas de coleta.
 4. Os documentos são salvos nas pastas `data/xmls/<CNPJ>/` e `data/html/<CNPJ>/` e registrados no banco SQLite.
 
+## Emissão de NFS-e Goiânia (ISSNet Online)
+- A emissão é feita com certificado A1 (`.pfx`) via automação HTTP do portal do ISSNet Online.
+- O XML é salvo automaticamente em `data/nfse/<CNPJ>/<ANO>/<MES>/NFSe-<numero>-<competencia>.xml` e o resumo opcional em `.json`.
+- Requisitos adicionais:
+  - `pytesseract` + mecanismo Tesseract instalado no sistema para resolver o captcha automaticamente (Linux: `sudo apt install tesseract-ocr`; Windows: [instalador oficial](https://github.com/UB-Mannheim/tesseract/wiki)).
+  - Certificado `.pfx` da empresa na pasta `certs/` e senha correspondente.
+
+### Passo a passo (CLI)
+1. Cadastre a empresa no painel Streamlit, informando CNPJ e senha do certificado.
+2. Preencha um arquivo YAML/JSON seguindo o modelo `nfse_payload.example.yml`.
+3. Execute a emissão:
+   ```bash
+   ./nfse_emit.sh --empresa 12.345.678/0001-90 --senha-cert SUASENHA --input nfse_payload.example.yml --salvar-json
+   ```
+   - No Windows, utilize: `nfse_emit.bat --empresa 12.345.678/0001-90 --senha-cert SUASENHA --input nfse_payload.example.yml --salvar-json`
+   - Parâmetros opcionais `--usuario-portal` e `--senha-portal` permitem informar credenciais diferentes do CNPJ.
+4. O script cria/usa `.venv`, instala dependências e grava os arquivos no diretório `data/nfse/` respeitando empresa/ano/mês.
+5. Em caso de mudança de layout ou captcha complexo, o módulo registra logs em `logs/coletor.log` para ajuste rápido.
+
 ## Execução com Systemd
 O script `install.sh` configura o ambiente em servidores Linux (Ubuntu) criando um serviço systemd para o painel Streamlit. Revise o arquivo antes de executar para ajustar caminhos ou usuário do serviço.
 

--- a/app/config.py
+++ b/app/config.py
@@ -31,11 +31,18 @@ class Settings:
     log_dir: Path = Path(os.getenv("LOG_DIR", BASE_DIR / "logs"))
     xml_dir: Path = Path(os.getenv("XML_DIR", BASE_DIR / "data" / "xmls"))
     html_dir: Path = Path(os.getenv("HTML_DIR", BASE_DIR / "data" / "html"))
+    nfse_dir: Path = Path(os.getenv("NFSE_DIR", BASE_DIR / "data" / "nfse"))
     certs_dir: Path = Path(os.getenv("CERTS_DIR", BASE_DIR / "certs"))
 
     def ensure_directories(self) -> None:
         """Garante a existência dos diretórios necessários."""
-        for path in (self.log_dir, self.xml_dir, self.html_dir, self.certs_dir):
+        for path in (
+            self.log_dir,
+            self.xml_dir,
+            self.html_dir,
+            self.nfse_dir,
+            self.certs_dir,
+        ):
             path.mkdir(parents=True, exist_ok=True)
 
 

--- a/app/nfse/__init__.py
+++ b/app/nfse/__init__.py
@@ -1,0 +1,5 @@
+"""Integração NFS-e Goiânia (ISSNet Online)."""
+
+from .goiania import IssnetEndpoints, NfseGoianiaClient  # noqa: F401
+from .schemas import DadosServico, DadosTomador, NotaServico  # noqa: F401
+from .storage import gerar_caminho_nfse  # noqa: F401

--- a/app/nfse/cli.py
+++ b/app/nfse/cli.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import yaml
 
-from ..database import session_scope
+from ..database import init_db, session_scope
 from ..models import Empresa
 from ..utils.cnpj import sanitize_cnpj
 from ..utils.helpers import setup_logging
@@ -69,13 +69,24 @@ def criar_nota(payload: dict[str, Any]) -> NotaServico:
     )
 
     competencia = payload.get("competencia")
-    if isinstance(competencia, str):
-        ano, mes, dia = competencia.split("-") + ["01"] * (3 - len(competencia.split("-")))
-        competencia_date = date(int(ano), int(mes), int(dia))
-    elif isinstance(competencia, (list, tuple)):
-        competencia_date = date(int(competencia[0]), int(competencia[1]), int(competencia[2]))
-    else:
-        competencia_date = date.today()
+
+    try:
+        if isinstance(competencia, str):
+            partes = competencia.split("-")
+            while len(partes) < 3:
+                partes.append("01")
+            ano, mes, dia = (int(v) for v in partes[:3])
+            competencia_date = date(ano, mes, dia)
+        elif isinstance(competencia, (list, tuple)):
+            partes_seq = list(competencia)
+            while len(partes_seq) < 3:
+                partes_seq.append(1)
+            ano, mes, dia = (int(v) for v in partes_seq[:3])
+            competencia_date = date(ano, mes, dia)
+        else:
+            competencia_date = date.today()
+    except Exception as exc:
+        raise ValueError(f"Competência inválida: {competencia}") from exc
 
     return NotaServico(
         competencia=competencia_date,
@@ -95,16 +106,37 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    empresa = carregar_empresa(args.empresa)
-    payload = carregar_payload(Path(args.input))
-    nota = criar_nota(payload)
+    init_db()
 
-    cliente = NfseGoianiaClient(
-        empresa=empresa,
-        senha_certificado=args.senha_cert,
-        usuario_portal=args.usuario_portal,
-        senha_portal=args.senha_portal,
-    )
+    try:
+        empresa = carregar_empresa(args.empresa)
+    except Exception as exc:
+        LOGGER.error("Erro ao carregar empresa: %s", exc)
+        raise SystemExit(1) from exc
+
+    try:
+        payload = carregar_payload(Path(args.input))
+        nota = criar_nota(payload)
+    except ValueError as exc:
+        LOGGER.error(str(exc))
+        raise SystemExit(1) from exc
+    except Exception as exc:
+        LOGGER.error("Erro ao ler o payload: %s", exc)
+        raise SystemExit(1) from exc
+
+    try:
+        cliente = NfseGoianiaClient(
+            empresa=empresa,
+            senha_certificado=args.senha_cert,
+            usuario_portal=args.usuario_portal,
+            senha_portal=args.senha_portal,
+        )
+    except FileNotFoundError as exc:
+        LOGGER.error("Certificado não encontrado: %s", exc)
+        raise SystemExit(1) from exc
+    except Exception as exc:
+        LOGGER.error("Erro ao preparar o cliente NFS-e: %s", exc)
+        raise SystemExit(1) from exc
 
     try:
         if args.salvar_json:

--- a/app/nfse/cli.py
+++ b/app/nfse/cli.py
@@ -36,8 +36,43 @@ def carregar_payload(caminho: Path) -> dict[str, Any]:
         raise SystemExit(f"Arquivo de entrada {caminho} não encontrado.")
 
     if caminho.suffix.lower() in {".yaml", ".yml"}:
-        return yaml.safe_load(caminho.read_text(encoding="utf-8"))
-    return json.loads(caminho.read_text(encoding="utf-8"))
+        payload = yaml.safe_load(caminho.read_text(encoding="utf-8"))
+    else:
+        payload = json.loads(caminho.read_text(encoding="utf-8"))
+
+    if not payload:
+        raise SystemExit(f"O arquivo {caminho} está vazio ou inválido.")
+
+    return payload
+
+
+def validar_payload(payload: dict[str, Any]) -> None:
+    """Valida campos obrigatórios do payload da NFS-e com mensagens claras."""
+
+    def exige_dict(chave: str) -> dict[str, Any]:
+        bloco = payload.get(chave)
+        if not isinstance(bloco, dict):
+            raise ValueError(f"A seção '{chave}' deve ser um objeto com os campos necessários.")
+        return bloco
+
+    tomador = exige_dict("tomador")
+    servico = exige_dict("servico")
+
+    obrigatorios_tomador = ["razao_social", "documento"]
+    obrigatorios_servico = ["codigo_tributacao", "valor_servico", "discriminacao"]
+
+    for campo in obrigatorios_tomador:
+        if not tomador.get(campo):
+            raise ValueError(f"Campo obrigatório ausente em tomador: '{campo}'.")
+
+    for campo in obrigatorios_servico:
+        if servico.get(campo) in (None, ""):
+            raise ValueError(f"Campo obrigatório ausente em servico: '{campo}'.")
+
+    if "competencia" in payload:
+        competencia = payload["competencia"]
+        if not isinstance(competencia, (str, list, tuple)):
+            raise ValueError("Competência deve ser string 'AAAA-MM' ou sequência [AAAA, MM, DD].")
 
 
 def criar_nota(payload: dict[str, Any]) -> NotaServico:
@@ -116,6 +151,7 @@ def main() -> None:
 
     try:
         payload = carregar_payload(Path(args.input))
+        validar_payload(payload)
         nota = criar_nota(payload)
     except ValueError as exc:
         LOGGER.error(str(exc))

--- a/app/nfse/cli.py
+++ b/app/nfse/cli.py
@@ -1,0 +1,126 @@
+"""Interface de linha de comando para emissão de NFS-e de Goiânia."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..database import session_scope
+from ..models import Empresa
+from ..utils.cnpj import sanitize_cnpj
+from ..utils.helpers import setup_logging
+from .goiania import NfseException, NfseGoianiaClient
+from .schemas import DadosServico, DadosTomador, NotaServico
+
+LOGGER = setup_logging()
+
+
+def carregar_empresa(cnpj: str) -> Empresa:
+    cnpj_limpo = sanitize_cnpj(cnpj)
+    with session_scope() as session:
+        empresa = session.query(Empresa).filter_by(cnpj=cnpj_limpo).one_or_none()
+        if not empresa:
+            raise SystemExit(f"Empresa {cnpj_limpo} não encontrada. Cadastre-a pelo painel.")
+        session.expunge(empresa)
+    return empresa
+
+
+def carregar_payload(caminho: Path) -> dict[str, Any]:
+    if not caminho.exists():
+        raise SystemExit(f"Arquivo de entrada {caminho} não encontrado.")
+
+    if caminho.suffix.lower() in {".yaml", ".yml"}:
+        return yaml.safe_load(caminho.read_text(encoding="utf-8"))
+    return json.loads(caminho.read_text(encoding="utf-8"))
+
+
+def criar_nota(payload: dict[str, Any]) -> NotaServico:
+    tomador = payload.get("tomador", {})
+    servico = payload.get("servico", {})
+
+    dados_tomador = DadosTomador(
+        razao_social=tomador["razao_social"],
+        documento=sanitize_cnpj(tomador["documento"]),
+        inscricao_municipal=tomador.get("inscricao_municipal"),
+        email=tomador.get("email"),
+        endereco=tomador.get("endereco"),
+        bairro=tomador.get("bairro"),
+        cep=tomador.get("cep"),
+        municipio=tomador.get("municipio"),
+        uf=tomador.get("uf"),
+    )
+
+    dados_servico = DadosServico(
+        codigo_tributacao=str(servico["codigo_tributacao"]),
+        aliquota=Decimal(str(servico.get("aliquota", "0"))),
+        valor_servico=Decimal(str(servico["valor_servico"])),
+        discriminacao=servico["discriminacao"],
+        iss_retido=bool(servico.get("iss_retido", False)),
+        deducoes=Decimal(str(servico.get("deducoes", "0"))),
+        codigo_cnae=servico.get("codigo_cnae"),
+        codigo_municipio=servico.get("codigo_municipio"),
+        codigo_prestador=servico.get("codigo_prestador"),
+    )
+
+    competencia = payload.get("competencia")
+    if isinstance(competencia, str):
+        ano, mes, dia = competencia.split("-") + ["01"] * (3 - len(competencia.split("-")))
+        competencia_date = date(int(ano), int(mes), int(dia))
+    elif isinstance(competencia, (list, tuple)):
+        competencia_date = date(int(competencia[0]), int(competencia[1]), int(competencia[2]))
+    else:
+        competencia_date = date.today()
+
+    return NotaServico(
+        competencia=competencia_date,
+        tomador=dados_tomador,
+        servico=dados_servico,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Emissor de NFS-e Goiânia - ISSNet Online")
+    parser.add_argument("--empresa", required=True, help="CNPJ da empresa emissora cadastrada")
+    parser.add_argument("--senha-cert", required=True, help="Senha do certificado PFX")
+    parser.add_argument("--input", required=True, help="Arquivo YAML/JSON com dados da nota")
+    parser.add_argument("--usuario-portal", help="Usuário do portal ISSNet (opcional)")
+    parser.add_argument("--senha-portal", help="Senha do portal ISSNet (opcional)")
+    parser.add_argument("--salvar-json", action="store_true", help="Salvar resumo JSON junto ao XML")
+
+    args = parser.parse_args()
+
+    empresa = carregar_empresa(args.empresa)
+    payload = carregar_payload(Path(args.input))
+    nota = criar_nota(payload)
+
+    cliente = NfseGoianiaClient(
+        empresa=empresa,
+        senha_certificado=args.senha_cert,
+        usuario_portal=args.usuario_portal,
+        senha_portal=args.senha_portal,
+    )
+
+    try:
+        if args.salvar_json:
+            cliente.emitir_e_salvar_json(nota)
+        else:
+            cliente.emitir_nfse(nota)
+    except NfseException as exc:
+        LOGGER.error("Erro ao emitir NFS-e: %s", exc)
+        raise SystemExit(1) from exc
+
+    LOGGER.info(
+        "NFS-e emitida com sucesso | Número: %s | XML: %s",
+        nota.numero_nfse,
+        nota.arquivo_salvo,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/app/nfse/goiania.py
+++ b/app/nfse/goiania.py
@@ -277,9 +277,10 @@ class NfseGoianiaClient:
         if nota.xml_url:
             resp = self._get(nota.xml_url)
         else:
+            if not nota.numero_nfse:
+                raise NfseException("Número da NFS-e ausente; não é possível baixar o XML.")
             params = {"numero": nota.numero_nfse, "competencia": nota.competencia.strftime("%Y-%m")}
-            resp = self._session.post(self.endpoints.download_url, data=params, timeout=30)
-            resp.raise_for_status()
+            resp = self._post(self.endpoints.download_url, data=params)
 
         nome_arquivo = f"NFSe-{nota.numero_nfse}-{nota.competencia.strftime('%Y%m')}.xml"
         destino = gerar_caminho_nfse(self.empresa.cnpj, nota.competencia, nome_arquivo)

--- a/app/nfse/goiania.py
+++ b/app/nfse/goiania.py
@@ -1,0 +1,319 @@
+"""Cliente de emissão de NFS-e para a Prefeitura de Goiânia (ISSNet Online)."""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Optional
+
+import requests
+from bs4 import BeautifulSoup
+from requests_pkcs12 import Pkcs12Adapter
+from tenacity import RetryError, retry, stop_after_attempt, wait_exponential
+
+from ..config import settings
+from ..models import Empresa
+from ..utils.certificado import carregar_certificado
+from ..utils.helpers import setup_logging
+from .schemas import NotaServico
+from .storage import gerar_caminho_nfse
+
+LOGGER = setup_logging()
+
+
+class NfseException(RuntimeError):
+    """Erro genérico durante a emissão ou download da NFS-e."""
+
+
+@dataclass
+class IssnetEndpoints:
+    """Coleção de URLs utilizadas pelo portal ISSNet Online de Goiânia."""
+
+    base_url: str = "https://issonline.goiania.go.gov.br/issnetonline"
+    login_path: str = "/Account/Login"
+    emissao_path: str = "/Nfse/Emissao"
+    download_path: str = "/Nfse/DownloadXml"
+    captcha_path: str = "/Account/Captcha"
+
+    def __post_init__(self) -> None:
+        self.base_url = self.base_url.rstrip("/")
+
+    @property
+    def login_url(self) -> str:
+        return f"{self.base_url}{self.login_path}"
+
+    @property
+    def emissao_url(self) -> str:
+        return f"{self.base_url}{self.emissao_path}"
+
+    @property
+    def download_url(self) -> str:
+        return f"{self.base_url}{self.download_path}"
+
+    @property
+    def captcha_url(self) -> str:
+        return f"{self.base_url}{self.captcha_path}"
+
+
+class CaptchaSolver:
+    """Resolve captchas simples do portal (imagem estática)."""
+
+    def __init__(self) -> None:
+        try:
+            import pytesseract  # type: ignore
+            from PIL import Image  # noqa: F401
+
+            self._ocr = pytesseract
+        except Exception:  # pragma: no cover - usado apenas se disponível
+            self._ocr = None
+
+    def solve(self, image_bytes: bytes, manual_callback: Optional[Callable[[bytes], str]] = None) -> str:
+        """Tenta resolver via OCR e, se falhar, utiliza entrada manual."""
+        if self._ocr:
+            try:
+                from PIL import Image
+
+                text = self._ocr.image_to_string(Image.open(io.BytesIO(image_bytes)), config="--psm 7")
+                cleaned = re.sub(r"\W+", "", text).strip()
+                if cleaned:
+                    return cleaned
+            except Exception as exc:  # pragma: no cover
+                LOGGER.warning("Falha no OCR do captcha: %s", exc)
+
+        if manual_callback:
+            return manual_callback(image_bytes)
+        raise NfseException("Não foi possível resolver o captcha automaticamente. Forneça um callback manual.")
+
+
+class NfseGoianiaClient:
+    """Cliente de alto nível para emissão e download de NFS-e no ISSNet Online."""
+
+    def __init__(
+        self,
+        empresa: Empresa,
+        senha_certificado: str,
+        usuario_portal: Optional[str] = None,
+        senha_portal: Optional[str] = None,
+        endpoints: Optional[IssnetEndpoints] = None,
+        captcha_solver: Optional[CaptchaSolver] = None,
+    ) -> None:
+        self.empresa = empresa
+        self.senha_certificado = senha_certificado
+        self.usuario_portal = usuario_portal or empresa.cnpj
+        self.senha_portal = senha_portal or senha_certificado
+        self.endpoints = endpoints or IssnetEndpoints()
+        self._captcha_solver = captcha_solver or CaptchaSolver()
+        self._session = self._criar_sessao()
+
+    def _criar_sessao(self) -> requests.Session:
+        certificado, senha = carregar_certificado(self.empresa.cnpj, self.senha_certificado)
+        session = requests.Session()
+        session.mount("https://", Pkcs12Adapter(pkcs12_filename=str(certificado), pkcs12_password=senha))
+        session.headers.update({
+            "User-Agent": "Coletor-Fiscal-NFSe/1.0",
+            "Accept-Language": "pt-BR,pt;q=0.9",
+        })
+        return session
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=5))
+    def _get(self, url: str) -> requests.Response:
+        resp = self._session.get(url, timeout=30)
+        resp.raise_for_status()
+        return resp
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=5))
+    def _post(self, url: str, data: dict[str, str]) -> requests.Response:
+        resp = self._session.post(url, data=data, timeout=30)
+        resp.raise_for_status()
+        return resp
+
+    def _resolver_captcha(self) -> str:
+        resp = self._get(self.endpoints.captcha_url)
+        return self._captcha_solver.solve(resp.content, manual_callback=self._manual_captcha)
+
+    def _manual_captcha(self, image_bytes: bytes) -> str:
+        destino = settings.log_dir / f"captcha-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}.png"
+        destino.write_bytes(image_bytes)
+        LOGGER.warning(
+            "Captcha salvo em %s. Informe o texto manualmente para continuar.", destino
+        )
+        return input("Captcha exibido no arquivo salvo: ").strip()
+
+    def _extrair_hidden_inputs(self, html: str) -> dict[str, str]:
+        soup = BeautifulSoup(html, "lxml")
+        data: dict[str, str] = {}
+        for hidden in soup.select("input[type='hidden']"):
+            if hidden.get("name"):
+                data[hidden["name"]] = hidden.get("value", "")
+        return data
+
+    def login(self) -> None:
+        LOGGER.info("Abrindo página de login do ISSNet Online para %s", self.empresa.cnpj)
+        resp = self._get(self.endpoints.login_url)
+        payload = self._extrair_hidden_inputs(resp.text)
+        captcha_codigo = self._resolver_captcha()
+
+        form_soup = BeautifulSoup(resp.text, "lxml")
+        usuario_field = None
+        senha_field = None
+        captcha_field = None
+        for inp in form_soup.select("input"):
+            name = inp.get("name", "").lower()
+            if not usuario_field and ("cnpj" in name or "usuario" in name or "login" in name):
+                usuario_field = inp.get("name")
+            if not senha_field and ("senha" in name or "password" in name):
+                senha_field = inp.get("name")
+            if not captcha_field and "captcha" in name:
+                captcha_field = inp.get("name")
+
+        if not usuario_field or not senha_field:
+            raise NfseException("Campos de usuário/senha não encontrados no formulário de login.")
+
+        payload.update({
+            usuario_field: self.usuario_portal,
+            senha_field: self.senha_portal,
+        })
+        if captcha_field:
+            payload[captcha_field] = captcha_codigo
+
+        resp_login = self._post(self.endpoints.login_url, payload)
+        if "NFS-e" not in resp_login.text and resp_login.url.endswith("Login"):
+            raise NfseException("Login não autorizado no ISSNet Online.")
+        LOGGER.info("Login realizado com sucesso para %s", self.empresa.nome)
+
+    def _montar_payload_emissao(self, nota: NotaServico, html: str) -> dict[str, str]:
+        soup = BeautifulSoup(html, "lxml")
+        payload = self._extrair_hidden_inputs(html)
+
+        campos = {
+            "valor": ["txtValorServico", "valorServico", "ValorServico"],
+            "discriminacao": ["txtDiscriminacao", "Discriminacao"],
+            "codigo_tributacao": ["txtCodTributacao", "CodigoServico"],
+            "aliquota": ["txtAliquota", "Aliquota"],
+            "documento_tomador": ["txtCpfCnpjTomador", "DocumentoTomador"],
+            "razao_tomador": ["txtRazaoSocialTomador", "RazaoSocialTomador"],
+            "email_tomador": ["txtEmailTomador", "EmailTomador"],
+            "inscricao_municipal": ["txtInscMunicipalTomador", "InscricaoMunicipalTomador"],
+        }
+
+        def set_first(names: list[str], value: str | None) -> None:
+            if value is None:
+                return
+            for name in names:
+                if soup.find("input", {"name": name}) or soup.find("textarea", {"name": name}):
+                    payload[name] = value
+                    return
+
+        set_first(campos["valor"], str(nota.servico.valor_servico))
+        set_first(campos["discriminacao"], nota.servico.discriminacao)
+        set_first(campos["codigo_tributacao"], nota.servico.codigo_tributacao)
+        set_first(campos["aliquota"], str(nota.servico.aliquota))
+        set_first(campos["documento_tomador"], nota.tomador.documento)
+        set_first(campos["razao_tomador"], nota.tomador.razao_social)
+        set_first(campos["email_tomador"], nota.tomador.email)
+        set_first(campos["inscricao_municipal"], nota.tomador.inscricao_municipal or "")
+
+        if nota.servico.iss_retido:
+            for field in ("chkIssRetido", "IssRetido"):
+                if soup.find("input", {"name": field}):
+                    payload[field] = "on"
+
+        if nota.servico.deducoes:
+            for field in ("txtDeducoes", "ValorDeducoes"):
+                if soup.find("input", {"name": field}):
+                    payload[field] = str(nota.servico.deducoes)
+
+        return payload
+
+    def emitir_nfse(self, nota: NotaServico, salvar_xml: bool = True) -> NotaServico:
+        try:
+            self.login()
+        except RetryError as exc:  # pragma: no cover - exceção de rede
+            raise NfseException(f"Falha ao autenticar no ISSNet Online: {exc}") from exc
+
+        LOGGER.info("Acessando formulário de emissão de NFS-e")
+        resp_form = self._get(self.endpoints.emissao_url)
+        payload = self._montar_payload_emissao(nota, resp_form.text)
+
+        LOGGER.info("Enviando dados da NFS-e para emissão")
+        resp_emitir = self._post(self.endpoints.emissao_url, payload)
+        texto_retorno = resp_emitir.text
+
+        numero = self._buscar_regex(texto_retorno, r"NFSe\s*:?\s*(\d+)")
+        codigo = self._buscar_regex(texto_retorno, r"C[oó]digo de Verifica[cç][aã]o\s*:?\s*([A-Za-z0-9-]+)")
+        xml_link = self._extrair_link_xml(resp_emitir.text)
+
+        if not numero:
+            raise NfseException("O portal não retornou o número da NFS-e. Verifique os dados enviados e o layout atual.")
+
+        nota.numero_nfse = numero
+        nota.codigo_verificacao = codigo
+        nota.xml_url = xml_link
+        LOGGER.info("NFS-e %s emitida com sucesso", numero)
+
+        if salvar_xml:
+            self.baixar_xml(nota)
+        return nota
+
+    def _buscar_regex(self, texto: str, pattern: str) -> Optional[str]:
+        encontrado = re.search(pattern, texto, flags=re.IGNORECASE)
+        return encontrado.group(1).strip() if encontrado else None
+
+    def _extrair_link_xml(self, html: str) -> Optional[str]:
+        soup = BeautifulSoup(html, "lxml")
+        for link in soup.find_all("a"):
+            href = link.get("href", "")
+            if "xml" in href.lower():
+                if href.startswith("http"):
+                    return href
+                return f"{self.endpoints.base_url}{href}"
+        return None
+
+    def baixar_xml(self, nota: NotaServico) -> str:
+        if nota.xml_url:
+            resp = self._get(nota.xml_url)
+        else:
+            params = {"numero": nota.numero_nfse, "competencia": nota.competencia.strftime("%Y-%m")}
+            resp = self._session.post(self.endpoints.download_url, data=params, timeout=30)
+            resp.raise_for_status()
+
+        nome_arquivo = f"NFSe-{nota.numero_nfse}-{nota.competencia.strftime('%Y%m')}.xml"
+        destino = gerar_caminho_nfse(self.empresa.cnpj, nota.competencia, nome_arquivo)
+        destino.write_bytes(resp.content)
+        nota.arquivo_salvo = str(destino)
+        LOGGER.info("XML da NFS-e salvo em %s", destino)
+        return str(destino)
+
+    def emitir_e_salvar_json(self, nota: NotaServico, destino_json: Optional[str] = None) -> str:
+        """Emite a nota e salva um espelho em JSON junto ao XML."""
+        nota_emitida = self.emitir_nfse(nota, salvar_xml=True)
+        destino_json = destino_json or nota_emitida.arquivo_salvo.replace(".xml", ".json")
+        payload = {
+            "numero": nota_emitida.numero_nfse,
+            "codigo_verificacao": nota_emitida.codigo_verificacao,
+            "competencia": nota_emitida.competencia.isoformat(),
+            "tomador": nota_emitida.tomador.__dict__,
+            "servico": {
+                "codigo_tributacao": nota_emitida.servico.codigo_tributacao,
+                "aliquota": str(nota_emitida.servico.aliquota),
+                "valor_servico": str(nota_emitida.servico.valor_servico),
+                "discriminacao": nota_emitida.servico.discriminacao,
+                "iss_retido": nota_emitida.servico.iss_retido,
+                "deducoes": str(nota_emitida.servico.deducoes),
+            },
+            "arquivo_xml": nota_emitida.arquivo_salvo,
+        }
+        Path(destino_json).write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        LOGGER.info("Resumo da NFS-e salvo em %s", destino_json)
+        return destino_json
+
+
+__all__ = [
+    "NfseGoianiaClient",
+    "IssnetEndpoints",
+    "NfseException",
+]

--- a/app/nfse/schemas.py
+++ b/app/nfse/schemas.py
@@ -1,0 +1,57 @@
+"""Estruturas de dados para emissão de NFS-e de Goiânia."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+
+@dataclass
+class DadosTomador:
+    """Informações do tomador do serviço."""
+
+    razao_social: str
+    documento: str
+    inscricao_municipal: str | None = None
+    email: str | None = None
+    endereco: str | None = None
+    bairro: str | None = None
+    cep: str | None = None
+    municipio: str | None = None
+    uf: str | None = None
+
+
+@dataclass
+class DadosServico:
+    """Informações específicas do serviço prestado."""
+
+    codigo_tributacao: str
+    aliquota: Decimal
+    valor_servico: Decimal
+    discriminacao: str
+    iss_retido: bool = False
+    deducoes: Decimal = Decimal("0")
+    codigo_cnae: str | None = None
+    codigo_municipio: str | None = None
+    codigo_prestador: str | None = None
+
+
+@dataclass
+class NotaServico:
+    """Representa uma NFS-e a ser emitida."""
+
+    competencia: date
+    tomador: DadosTomador
+    servico: DadosServico
+    numero_nfse: Optional[str] = None
+    codigo_verificacao: Optional[str] = None
+    xml_url: Optional[str] = None
+    arquivo_salvo: Optional[str] = None
+    meta: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def competencia_str(self) -> str:
+        """Retorna a competência no formato AAAA-MM."""
+        return self.competencia.strftime("%Y-%m")

--- a/app/nfse/storage.py
+++ b/app/nfse/storage.py
@@ -1,0 +1,18 @@
+"""Utilidades para armazenamento de NFS-e."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from ..config import settings
+from ..utils.helpers import ensure_subdirectories
+
+
+def gerar_caminho_nfse(cnpj: str, competencia: date, nome_arquivo: str) -> Path:
+    """Cria o caminho padronizado empresa/ano/mes para salvar XML da NFS-e."""
+    base = settings.nfse_dir / cnpj
+    ano = f"{competencia.year:04d}"
+    mes = f"{competencia.month:02d}"
+    ensure_subdirectories(base, [ano, f"{ano}/{mes}"])
+    return base / ano / mes / nome_arquivo

--- a/docs/nfse_amtec_analysis.md
+++ b/docs/nfse_amtec_analysis.md
@@ -1,0 +1,30 @@
+# Avaliação do pacote `sped-nfse-amtec` (Goiânia)
+
+Esta análise resume o que o pacote PHP [`nfephp-org/sped-nfse-amtec`](https://github.com/andrentfs/sped-nfse-amtec) oferece e como ele poderia ser integrado ao fluxo atual de emissão de NFS-e via ISSNet Online.
+
+## Características principais do pacote
+- **Tecnologia**: biblioteca PHP distribuída via Composer.
+- **Padrão**: ABRASF 2.0 com adaptações do modelo AMTEC da Prefeitura de Goiânia.
+- **Escopo**: exclusivo para Goiânia/GO (IBGE 5208707, SIAF 9373).
+- **Transporte**: SOAP 1.2 com certificado A1 (PFX) no endpoint único `https://nfse.goiania.go.gov.br/ws/nfse.asmx` e namespace `http://nfse.goiania.go.gov.br/xsd/nfse_gyn_v02.xsd`.
+- **WSDL/XSD**: publicados em `https://nfse.goiania.go.gov.br/ws/nfse.asmx?wsdl` e `https://nfse.goiania.go.gov.br/xsd/nfse_gyn_v02.xsd`.
+- **Métodos disponíveis**: somente `GerarNfse` (um RPS por vez) e `ConsultarNfseRps`.
+- **Ambiente**: um único endpoint suporta TESTE e PRODUÇÃO; começa em TESTE e muda para PRODUÇÃO via solicitação por e-mail.
+- **Restrições de certificado**: o PFX deve ser emitido para o CNPJ cadastrado na prefeitura (não aceita CNPJ raiz genérico).
+- **Limitações**: não há cancelamento via webservice e algumas tags ABRASF 2.0 são proibidas ou opcionais (ex.: `ValorIss`, `ItemListaServico`, `Competencia`, `OptanteSimplesNacional`).
+
+## Implicações para o sistema atual
+- O projeto é PHP e depende de Composer/PSR, enquanto o nosso emissor é Python com automação HTTP do ISSNet Online. A integração direta exigiria:
+  - **Camada ponte**: expor o pacote via microserviço PHP (container) ou CLI e consumi-lo a partir da nossa CLI Python.
+  - **Reimplementação em Python**: replicar os envelopes SOAP usando `zeep`/`requests_pkcs12` com o WSDL público e respeitar as adaptações do XSD (remoção de campos não aceitos).
+- O pacote opera com **ambiente sempre de produção** (apenas modo TESTE/PRODUÇÃO no mesmo endpoint). Isso elimina a possibilidade de um ambiente de homologação separado e exige controles claros de modo de envio.
+- Como só há **`GerarNfse` síncrono** (sem lote) e **`ConsultarNfseRps`**, continuariam ausentes operações de cancelamento ou consulta por intervalo. O fluxo de download/armazenamento local (já implementado) precisaria consumir a resposta do SOAP.
+- O manual reforça que várias tags ABRASF são proibidas ou não retornadas; nosso validador de payload teria de ser ajustado para remover campos como `ValorIss`, `Competencia`, `ItemListaServico` e `OptanteSimplesNacional` antes de montar o XML.
+
+## Passos recomendados caso a integração seja adotada
+1. **Escolher a estratégia**: microserviço PHP (Composer) ou reimplementação SOAP em Python.
+2. **Mapear payload**: alinhar `NotaServico`/YAML para o layout AMTEC, omitindo os campos proibidos e garantindo obrigatórios (`CodigoTributacaoMunicipio`, `tcCpfCnpj`, `tsInscricaoMunicipal`).
+3. **Gerenciar modos**: adicionar flag de TESTE/PRODUÇÃO no cadastro da empresa para enviar o parâmetro correto na requisição SOAP (mantendo endpoint único).
+4. **Autenticação**: reutilizar o carregamento PFX (`requests_pkcs12.Pkcs12Adapter`) para assinar as chamadas SOAP 1.2.
+5. **Consulta/armazenamento**: após `GerarNfse`, parsear o XML retornado (número, código de verificação) e armazenar em `data/nfse/<CNPJ>/<ANO>/<MES>/`, mantendo compatibilidade com nosso `storage`.
+6. **Fallback/convivência**: manter a automação ISSNet atual como fallback até que o fluxo SOAP esteja validado em produção.

--- a/nfse_emit.bat
+++ b/nfse_emit.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+set ROOT_DIR=%~dp0
+set VENV_DIR=%ROOT_DIR%\.venv
+
+if not exist "%VENV_DIR%" (
+    python -m venv "%VENV_DIR%"
+)
+
+call "%VENV_DIR%\Scripts\activate.bat"
+python -m pip install --upgrade pip
+python -m pip install -r "%ROOT_DIR%\requirements.txt"
+python -m app.nfse.cli %*

--- a/nfse_emit.bat
+++ b/nfse_emit.bat
@@ -3,6 +3,8 @@ setlocal
 set ROOT_DIR=%~dp0
 set VENV_DIR=%ROOT_DIR%\.venv
 
+pushd "%ROOT_DIR%"
+
 if not exist "%VENV_DIR%" (
     python -m venv "%VENV_DIR%"
 )
@@ -11,3 +13,4 @@ call "%VENV_DIR%\Scripts\activate.bat"
 python -m pip install --upgrade pip
 python -m pip install -r "%ROOT_DIR%\requirements.txt"
 python -m app.nfse.cli %*
+popd

--- a/nfse_emit.sh
+++ b/nfse_emit.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$ROOT_DIR/.venv"
+
+if [ ! -d "$VENV_DIR" ]; then
+  python3 -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+pip install --upgrade pip
+pip install -r "$ROOT_DIR/requirements.txt"
+
+python -m app.nfse.cli "$@"

--- a/nfse_emit.sh
+++ b/nfse_emit.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_DIR="$ROOT_DIR/.venv"
 
+cd "$ROOT_DIR"
+
 if [ ! -d "$VENV_DIR" ]; then
   python3 -m venv "$VENV_DIR"
 fi

--- a/nfse_payload.example.yml
+++ b/nfse_payload.example.yml
@@ -1,0 +1,19 @@
+# Exemplo de payload para emissão de NFS-e via CLI
+competencia: "2024-08-01"
+tomador:
+  razao_social: "Cliente Exemplo LTDA"
+  documento: "12.345.678/0001-90"
+  inscricao_municipal: "123456"
+  email: "financeiro@cliente.com"
+  endereco: "Avenida Exemplo, 123"
+  bairro: "Setor Central"
+  cep: "74000-000"
+  municipio: "Goiânia"
+  uf: "GO"
+servico:
+  codigo_tributacao: "07.02"
+  aliquota: 0.05
+  valor_servico: 1500.00
+  discriminacao: "Prestação de serviços de consultoria e suporte presencial"
+  iss_retido: false
+  deducoes: 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ zeep==4.2.1
 beautifulsoup4==4.12.3
 # LXML 5.3.x oferece wheels para Python 3.13 no Windows, evitando compilações manuais
 lxml==5.3.2
+tenacity==9.0.0
+PyYAML==6.0.2
+pillow==10.4.0
+pytesseract==0.3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ zeep==4.2.1
 beautifulsoup4==4.12.3
 # LXML 5.3.x oferece wheels para Python 3.13 no Windows, evitando compilações manuais
 lxml==5.3.2
-tenacity==9.0.0
+# Streamlit 1.36 requires tenacity<9; pin to a compatible version to avoid resolver conflicts
+tenacity==8.2.3
 PyYAML==6.0.2
 pillow==10.4.0
 pytesseract==0.3.10

--- a/start.bat
+++ b/start.bat
@@ -2,8 +2,8 @@
 SETLOCAL ENABLEDELAYEDEXPANSION
 
 REM Inicializa o painel Streamlit do Coletor Fiscal v3.2.
-REM - Ativa o ambiente virtual existente
-REM - Define porta e endereço de escuta
+REM - Garante ambiente virtual e dependencias
+REM - Define porta e endereco de escuta
 REM - Executa o painel web
 
 SET APP_DIR=%~dp0
@@ -11,12 +11,23 @@ SET VENV_DIR=%APP_DIR%\.venv
 SET STREAMLIT_ENTRY=%APP_DIR%web\app.py
 
 IF NOT EXIST "%VENV_DIR%\Scripts\activate.bat" (
-    echo [ERRO] Ambiente virtual nao encontrado em %VENV_DIR%.
-    echo Execute install.bat ou force_install.bat para preparar o ambiente.
+    echo [INFO] Ambiente virtual nao encontrado. Executando install.bat...
+    CALL "%APP_DIR%install.bat"
+)
+
+IF NOT EXIST "%VENV_DIR%\Scripts\activate.bat" (
+    echo [ERRO] Ambiente virtual nao foi criado. Verifique as mensagens anteriores.
     EXIT /B 1
 )
 
 CALL "%VENV_DIR%\Scripts\activate.bat"
+
+python -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('streamlit') else 1)"
+IF ERRORLEVEL 1 (
+    echo [INFO] Dependencias ausentes. Instalando requirements...
+    python -m pip install --upgrade pip
+    python -m pip install -r "%APP_DIR%requirements.txt"
+)
 
 IF NOT DEFINED PORTA (
     SET PORTA=8501


### PR DESCRIPTION
## Summary
- add ISSNet Online client for Goiânia with captcha handling, certificate login, emission, and XML download
- include CLI, sample payload, and Windows/Linux scripts to install dependencies and emit NFS-e storing XML by company/year/month
- document the new workflow and dependencies in the README and settings

## Testing
- python -m compileall app web

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b86dda5748329b1008ff6d77fae3c)